### PR TITLE
feat(habit): add correction capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-bujo
+/bujo
 
 # Test artifacts
 coverage.out

--- a/cmd/bujo/cmd/habit_delete_log.go
+++ b/cmd/bujo/cmd/habit_delete_log.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var habitDeleteLogCmd = &cobra.Command{
+	Use:   "delete-log <log-id>",
+	Short: "Delete a specific habit log entry",
+	Long: `Delete a specific habit log entry by its ID.
+
+Use 'bujo habit inspect <habit>' to see log IDs.
+
+Examples:
+  bujo habit inspect Gym    # See log IDs
+  bujo habit delete-log 42  # Delete log #42`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logID, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid log ID: %s", args[0])
+		}
+
+		err = habitService.DeleteLog(cmd.Context(), logID)
+		if err != nil {
+			return fmt.Errorf("failed to delete log: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ Deleted log #%d\n", logID)
+		return nil
+	},
+}
+
+func init() {
+	habitCmd.AddCommand(habitDeleteLogCmd)
+}

--- a/cmd/bujo/cmd/habit_inspect.go
+++ b/cmd/bujo/cmd/habit_inspect.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tj/go-naturaldate"
+	"github.com/typingincolor/bujo/internal/adapter/cli"
+	"github.com/typingincolor/bujo/internal/service"
+)
+
+var (
+	inspectFrom string
+	inspectTo   string
+)
+
+var habitInspectCmd = &cobra.Command{
+	Use:   "inspect <habit-name|#id>",
+	Short: "Show habit details and log history",
+	Long: `Show detailed information about a habit including individual log entries.
+
+By default shows the last 30 days. Use --from and --to to specify a date range.
+
+Examples:
+  bujo habit inspect Gym
+  bujo habit inspect #1
+  bujo habit inspect Gym --from 2025-12-01
+  bujo habit inspect Gym --from "last month"
+  bujo habit inspect Gym --from 2025-12-01 --to 2025-12-31`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nameOrID := args[0]
+		today := time.Now()
+
+		// Default: last 30 days
+		from := today.AddDate(0, 0, -30)
+		to := today
+
+		if inspectFrom != "" {
+			parsed, err := parseInspectDate(inspectFrom)
+			if err != nil {
+				return err
+			}
+			from = parsed
+		}
+
+		if inspectTo != "" {
+			parsed, err := parseInspectDate(inspectTo)
+			if err != nil {
+				return err
+			}
+			to = parsed
+		}
+
+		var details *service.HabitDetails
+		var err error
+
+		if strings.HasPrefix(nameOrID, "#") {
+			habitID, parseErr := strconv.ParseInt(nameOrID[1:], 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("invalid habit ID: %s", nameOrID)
+			}
+			details, err = habitService.InspectHabitByID(cmd.Context(), habitID, from, to, today)
+		} else {
+			details, err = habitService.InspectHabit(cmd.Context(), nameOrID, from, to, today)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to inspect habit: %w", err)
+		}
+
+		fmt.Print(cli.RenderHabitInspect(details))
+		return nil
+	},
+}
+
+func init() {
+	habitInspectCmd.Flags().StringVar(&inspectFrom, "from", "", "Start date (e.g., '2025-12-01', 'last month')")
+	habitInspectCmd.Flags().StringVar(&inspectTo, "to", "", "End date (e.g., '2025-12-31', 'yesterday')")
+	habitCmd.AddCommand(habitInspectCmd)
+}
+
+func parseInspectDate(s string) (time.Time, error) {
+	now := time.Now()
+
+	// Try standard date format first
+	if parsed, err := time.Parse("2006-01-02", s); err == nil {
+		return parsed, nil
+	}
+
+	// Try natural language parsing
+	parsed, err := naturaldate.Parse(s, now, naturaldate.WithDirection(naturaldate.Past))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid date: %s", s)
+	}
+
+	return parsed, nil
+}

--- a/cmd/bujo/cmd/habit_log.go
+++ b/cmd/bujo/cmd/habit_log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,22 +14,25 @@ import (
 var habitLogDate string
 
 var habitLogCmd = &cobra.Command{
-	Use:   "log <habit-name> [count]",
+	Use:   "log <habit-name|#id> [count]",
 	Short: "Log a habit completion",
 	Long: `Log a habit completion for today or a specific date.
 
 If the habit doesn't exist, it will be created automatically.
 Count defaults to 1 if not specified.
+Use #<id> to log by habit ID (shown in bujo habit output).
 
 Examples:
   bujo habit log Gym
   bujo habit log Water 8
   bujo habit log "Morning Run"
+  bujo habit log #1              (log by ID)
+  bujo habit log #2 5            (log by ID with count)
   bujo habit log Gym --date yesterday
   bujo habit log Gym -d 2026-01-05`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+		nameOrID := args[0]
 		count := 1
 
 		if len(args) > 1 {
@@ -48,17 +52,31 @@ Examples:
 			logDate = parsed
 		}
 
-		err := habitService.LogHabitForDate(cmd.Context(), name, count, logDate)
+		var err error
+		var displayName string
+
+		if strings.HasPrefix(nameOrID, "#") {
+			habitID, parseErr := strconv.ParseInt(nameOrID[1:], 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("invalid habit ID: %s", nameOrID)
+			}
+			err = habitService.LogHabitByIDForDate(cmd.Context(), habitID, count, logDate)
+			displayName = nameOrID
+		} else {
+			err = habitService.LogHabitForDate(cmd.Context(), nameOrID, count, logDate)
+			displayName = nameOrID
+		}
+
 		if err != nil {
 			return fmt.Errorf("failed to log habit: %w", err)
 		}
 
 		if habitLogDate != "" {
-			fmt.Fprintf(os.Stderr, "✓ Logged: %s for %s\n", name, habitLogDate)
+			fmt.Fprintf(os.Stderr, "✓ Logged: %s for %s\n", displayName, habitLogDate)
 		} else if count == 1 {
-			fmt.Fprintf(os.Stderr, "✓ Logged: %s\n", name)
+			fmt.Fprintf(os.Stderr, "✓ Logged: %s\n", displayName)
 		} else {
-			fmt.Fprintf(os.Stderr, "✓ Logged: %s (x%d)\n", name, count)
+			fmt.Fprintf(os.Stderr, "✓ Logged: %s (x%d)\n", displayName, count)
 		}
 
 		return nil

--- a/cmd/bujo/cmd/habit_rename.go
+++ b/cmd/bujo/cmd/habit_rename.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var habitRenameCmd = &cobra.Command{
+	Use:   "rename <old-name|#id> <new-name>",
+	Short: "Rename a habit",
+	Long: `Rename a habit to a new name.
+
+All existing logs are preserved under the new name.
+
+Examples:
+  bujo habit rename Gym Workout
+  bujo habit rename #1 "Morning Workout"`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		oldNameOrID := args[0]
+		newName := args[1]
+
+		var err error
+		var displayOld string
+
+		if strings.HasPrefix(oldNameOrID, "#") {
+			habitID, parseErr := strconv.ParseInt(oldNameOrID[1:], 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("invalid habit ID: %s", oldNameOrID)
+			}
+			err = habitService.RenameHabitByID(cmd.Context(), habitID, newName)
+			displayOld = oldNameOrID
+		} else {
+			err = habitService.RenameHabit(cmd.Context(), oldNameOrID, newName)
+			displayOld = oldNameOrID
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to rename habit: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ Renamed %s to %s\n", displayOld, newName)
+		return nil
+	},
+}
+
+func init() {
+	habitCmd.AddCommand(habitRenameCmd)
+}

--- a/cmd/bujo/cmd/habit_undo.go
+++ b/cmd/bujo/cmd/habit_undo.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var habitUndoCmd = &cobra.Command{
+	Use:   "undo <habit-name|#id>",
+	Short: "Undo the last habit log",
+	Long: `Undo (delete) the most recent log entry for a habit.
+
+Use this to correct mistakes when you accidentally log a habit.
+Use #<id> to specify the habit by ID (shown in bujo habit output).
+
+Examples:
+  bujo habit undo Gym
+  bujo habit undo #1`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nameOrID := args[0]
+
+		var err error
+		var displayName string
+
+		if strings.HasPrefix(nameOrID, "#") {
+			habitID, parseErr := strconv.ParseInt(nameOrID[1:], 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("invalid habit ID: %s", nameOrID)
+			}
+			err = habitService.UndoLastLogByID(cmd.Context(), habitID)
+			displayName = nameOrID
+		} else {
+			err = habitService.UndoLastLog(cmd.Context(), nameOrID)
+			displayName = nameOrID
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to undo habit: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ Undid last log for: %s\n", displayName)
+		return nil
+	},
+}
+
+func init() {
+	habitCmd.AddCommand(habitUndoCmd)
+}

--- a/internal/adapter/cli/renderer.go
+++ b/internal/adapter/cli/renderer.go
@@ -273,3 +273,37 @@ func renderMonthCalendar(days []service.DayStatus) string {
 func FormatDate(t time.Time) string {
 	return t.Format("2006-01-02")
 }
+
+func RenderHabitInspect(details *service.HabitDetails) string {
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString(fmt.Sprintf("📋 %s\n", cyan(bold(details.Name))))
+
+	// Stats line
+	streakColor := green
+	if details.CurrentStreak == 0 {
+		streakColor = red
+	}
+	sb.WriteString(fmt.Sprintf("Streak: %s | Goal: %d/day\n\n",
+		streakColor(fmt.Sprintf("%d days", details.CurrentStreak)),
+		details.GoalPerDay))
+
+	// Logs table
+	if len(details.Logs) == 0 {
+		sb.WriteString(dimmed("No logs in this period\n"))
+	} else {
+		sb.WriteString(bold("Logs:\n"))
+		sb.WriteString(dimmed("  ID      Date         Count\n"))
+		for _, log := range details.Logs {
+			sb.WriteString(fmt.Sprintf("  %-6d  %-11s  %d\n",
+				log.ID,
+				log.LoggedAt.Format("Jan 2, 2006"),
+				log.Count))
+		}
+	}
+
+	sb.WriteString(fmt.Sprintf("\n%s %d\n", dimmed("Habit ID:"), details.ID))
+
+	return sb.String()
+}

--- a/internal/service/habit.go
+++ b/internal/service/habit.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/typingincolor/bujo/internal/domain"
@@ -9,12 +10,18 @@ import (
 
 type HabitRepository interface {
 	GetOrCreate(ctx context.Context, name string, goalPerDay int) (*domain.Habit, error)
+	GetByID(ctx context.Context, id int64) (*domain.Habit, error)
+	GetByName(ctx context.Context, name string) (*domain.Habit, error)
 	GetAll(ctx context.Context) ([]domain.Habit, error)
+	Update(ctx context.Context, habit domain.Habit) error
 }
 
 type HabitLogRepository interface {
 	Insert(ctx context.Context, log domain.HabitLog) (int64, error)
+	GetByID(ctx context.Context, id int64) (*domain.HabitLog, error)
 	GetRange(ctx context.Context, habitID int64, start, end time.Time) ([]domain.HabitLog, error)
+	GetLastByHabitID(ctx context.Context, habitID int64) (*domain.HabitLog, error)
+	Delete(ctx context.Context, id int64) error
 }
 
 type HabitService struct {
@@ -49,7 +56,162 @@ func (s *HabitService) LogHabitForDate(ctx context.Context, name string, count i
 	return err
 }
 
+func (s *HabitService) LogHabitByID(ctx context.Context, habitID int64, count int) error {
+	return s.LogHabitByIDForDate(ctx, habitID, count, time.Now())
+}
+
+func (s *HabitService) LogHabitByIDForDate(ctx context.Context, habitID int64, count int, date time.Time) error {
+	habit, err := s.habitRepo.GetByID(ctx, habitID)
+	if err != nil {
+		return err
+	}
+	if habit == nil {
+		return fmt.Errorf("habit not found: %d", habitID)
+	}
+
+	log := domain.HabitLog{
+		HabitID:  habitID,
+		Count:    count,
+		LoggedAt: date,
+	}
+
+	_, err = s.logRepo.Insert(ctx, log)
+	return err
+}
+
+func (s *HabitService) UndoLastLog(ctx context.Context, name string) error {
+	habit, err := s.habitRepo.GetByName(ctx, name)
+	if err != nil {
+		return err
+	}
+	if habit == nil {
+		return fmt.Errorf("habit not found: %s", name)
+	}
+
+	return s.undoLastLogForHabit(ctx, habit.ID)
+}
+
+func (s *HabitService) UndoLastLogByID(ctx context.Context, habitID int64) error {
+	habit, err := s.habitRepo.GetByID(ctx, habitID)
+	if err != nil {
+		return err
+	}
+	if habit == nil {
+		return fmt.Errorf("habit not found: %d", habitID)
+	}
+
+	return s.undoLastLogForHabit(ctx, habitID)
+}
+
+func (s *HabitService) undoLastLogForHabit(ctx context.Context, habitID int64) error {
+	lastLog, err := s.logRepo.GetLastByHabitID(ctx, habitID)
+	if err != nil {
+		return err
+	}
+	if lastLog == nil {
+		return fmt.Errorf("no logs to undo")
+	}
+
+	return s.logRepo.Delete(ctx, lastLog.ID)
+}
+
+func (s *HabitService) DeleteLog(ctx context.Context, logID int64) error {
+	log, err := s.logRepo.GetByID(ctx, logID)
+	if err != nil {
+		return err
+	}
+	if log == nil {
+		return fmt.Errorf("log not found: %d", logID)
+	}
+
+	return s.logRepo.Delete(ctx, logID)
+}
+
+func (s *HabitService) RenameHabit(ctx context.Context, oldName, newName string) error {
+	habit, err := s.habitRepo.GetByName(ctx, oldName)
+	if err != nil {
+		return err
+	}
+	if habit == nil {
+		return fmt.Errorf("habit not found: %s", oldName)
+	}
+
+	habit.Name = newName
+	return s.habitRepo.Update(ctx, *habit)
+}
+
+func (s *HabitService) RenameHabitByID(ctx context.Context, habitID int64, newName string) error {
+	habit, err := s.habitRepo.GetByID(ctx, habitID)
+	if err != nil {
+		return err
+	}
+	if habit == nil {
+		return fmt.Errorf("habit not found: %d", habitID)
+	}
+
+	habit.Name = newName
+	return s.habitRepo.Update(ctx, *habit)
+}
+
+type HabitDetails struct {
+	ID                int64
+	Name              string
+	GoalPerDay        int
+	CurrentStreak     int
+	CompletionPercent float64
+	Logs              []domain.HabitLog
+}
+
+func (s *HabitService) InspectHabit(ctx context.Context, name string, from, to, today time.Time) (*HabitDetails, error) {
+	habit, err := s.habitRepo.GetByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if habit == nil {
+		return nil, fmt.Errorf("habit not found: %s", name)
+	}
+
+	return s.inspectHabitByHabit(ctx, habit, from, to, today)
+}
+
+func (s *HabitService) InspectHabitByID(ctx context.Context, habitID int64, from, to, today time.Time) (*HabitDetails, error) {
+	habit, err := s.habitRepo.GetByID(ctx, habitID)
+	if err != nil {
+		return nil, err
+	}
+	if habit == nil {
+		return nil, fmt.Errorf("habit not found: %d", habitID)
+	}
+
+	return s.inspectHabitByHabit(ctx, habit, from, to, today)
+}
+
+func (s *HabitService) inspectHabitByHabit(ctx context.Context, habit *domain.Habit, from, to, today time.Time) (*HabitDetails, error) {
+	// Get logs for the date range
+	logs, err := s.logRepo.GetRange(ctx, habit.ID, from, to.Add(24*time.Hour))
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate streak using all recent logs (not just the range)
+	todayStart := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+	streakLogs, err := s.logRepo.GetRange(ctx, habit.ID, todayStart.AddDate(0, 0, -365), todayStart.Add(24*time.Hour))
+	if err != nil {
+		return nil, err
+	}
+
+	return &HabitDetails{
+		ID:                habit.ID,
+		Name:              habit.Name,
+		GoalPerDay:        habit.GoalPerDay,
+		CurrentStreak:     domain.CalculateStreak(streakLogs, todayStart),
+		CompletionPercent: domain.CalculateCompletion(logs, int(to.Sub(from).Hours()/24)+1, todayStart),
+		Logs:              logs,
+	}, nil
+}
+
 type HabitStatus struct {
+	ID                int64
 	Name              string
 	GoalPerDay        int
 	CurrentStreak     int
@@ -90,6 +252,7 @@ func (s *HabitService) GetTrackerStatus(ctx context.Context, today time.Time, da
 		}
 
 		habitStatus := HabitStatus{
+			ID:                habit.ID,
 			Name:              habit.Name,
 			GoalPerDay:        habit.GoalPerDay,
 			CurrentStreak:     domain.CalculateStreak(logs, todayStart),

--- a/internal/service/habit_test.go
+++ b/internal/service/habit_test.go
@@ -134,3 +134,281 @@ func TestHabitService_GetTrackerStatus_DayHistory(t *testing.T) {
 	assert.Len(t, status.Habits[0].DayHistory, 7)
 	assert.InDelta(t, 100.0, status.Habits[0].CompletionPercent, 0.1)
 }
+
+func TestHabitService_GetTrackerStatus_IncludesHabitID(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, time.Now(), 7)
+
+	require.NoError(t, err)
+	assert.Greater(t, status.Habits[0].ID, int64(0))
+}
+
+func TestHabitService_LogHabitByID(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Create a habit first
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	habitID := status.Habits[0].ID
+
+	// Log by ID
+	err = service.LogHabitByID(ctx, habitID, 1)
+	require.NoError(t, err)
+
+	// Verify count increased
+	status, err = service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, 2, status.Habits[0].TodayCount)
+}
+
+func TestHabitService_LogHabitByID_NotFound(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	err := service.LogHabitByID(ctx, 99999, 1)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHabitService_UndoLastLog(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Log a habit twice
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+	err = service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, 2, status.Habits[0].TodayCount)
+
+	// Undo the last log
+	err = service.UndoLastLog(ctx, "Gym")
+	require.NoError(t, err)
+
+	// Verify count decreased
+	status, err = service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.Habits[0].TodayCount)
+}
+
+func TestHabitService_UndoLastLog_ByID(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Log a habit
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	habitID := status.Habits[0].ID
+
+	// Undo by ID
+	err = service.UndoLastLogByID(ctx, habitID)
+	require.NoError(t, err)
+
+	// Verify count is 0
+	status, err = service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, 0, status.Habits[0].TodayCount)
+}
+
+func TestHabitService_UndoLastLog_NotFound(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	err := service.UndoLastLog(ctx, "NonExistent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHabitService_UndoLastLog_NoLogs(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Create habit but don't log
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	// Undo the only log
+	err = service.UndoLastLog(ctx, "Gym")
+	require.NoError(t, err)
+
+	// Try to undo again - should fail
+	err = service.UndoLastLog(ctx, "Gym")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no logs")
+}
+
+func TestHabitService_InspectHabit(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	today := time.Date(2026, 1, 6, 12, 0, 0, 0, time.UTC)
+
+	// Log habit for multiple days
+	for i := 0; i < 5; i++ {
+		err := service.LogHabitForDate(ctx, "Gym", 1, today.AddDate(0, 0, -i))
+		require.NoError(t, err)
+	}
+
+	from := today.AddDate(0, 0, -30)
+	to := today
+
+	details, err := service.InspectHabit(ctx, "Gym", from, to, today)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Gym", details.Name)
+	assert.Greater(t, details.ID, int64(0))
+	assert.Len(t, details.Logs, 5)
+	assert.Equal(t, 5, details.CurrentStreak)
+}
+
+func TestHabitService_InspectHabitByID(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	today := time.Now()
+
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, today, 7)
+	require.NoError(t, err)
+	habitID := status.Habits[0].ID
+
+	from := today.AddDate(0, 0, -30)
+	to := today
+
+	details, err := service.InspectHabitByID(ctx, habitID, from, to, today)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Gym", details.Name)
+	assert.Len(t, details.Logs, 1)
+}
+
+func TestHabitService_InspectHabit_NotFound(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	today := time.Now()
+	from := today.AddDate(0, 0, -30)
+
+	_, err := service.InspectHabit(ctx, "NonExistent", from, today, today)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHabitService_DeleteLog(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	today := time.Now()
+
+	// Create logs
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+	err = service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	// Get the log IDs via inspect
+	from := today.AddDate(0, 0, -30)
+	details, err := service.InspectHabit(ctx, "Gym", from, today, today)
+	require.NoError(t, err)
+	require.Len(t, details.Logs, 2)
+
+	firstLogID := details.Logs[0].ID
+
+	// Delete the first log
+	err = service.DeleteLog(ctx, firstLogID)
+	require.NoError(t, err)
+
+	// Verify only one log remains
+	details, err = service.InspectHabit(ctx, "Gym", from, today, today)
+	require.NoError(t, err)
+	assert.Len(t, details.Logs, 1)
+}
+
+func TestHabitService_DeleteLog_NotFound(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	err := service.DeleteLog(ctx, 99999)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHabitService_RenameHabit(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Create a habit
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	// Rename it
+	err = service.RenameHabit(ctx, "Gym", "Workout")
+	require.NoError(t, err)
+
+	// Verify old name doesn't exist
+	today := time.Now()
+	from := today.AddDate(0, 0, -30)
+	_, err = service.InspectHabit(ctx, "Gym", from, today, today)
+	require.Error(t, err)
+
+	// Verify new name exists with the log
+	details, err := service.InspectHabit(ctx, "Workout", from, today, today)
+	require.NoError(t, err)
+	assert.Equal(t, "Workout", details.Name)
+	assert.Len(t, details.Logs, 1)
+}
+
+func TestHabitService_RenameHabitByID(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	// Create a habit
+	err := service.LogHabit(ctx, "Gym", 1)
+	require.NoError(t, err)
+
+	status, err := service.GetTrackerStatus(ctx, time.Now(), 7)
+	require.NoError(t, err)
+	habitID := status.Habits[0].ID
+
+	// Rename by ID
+	err = service.RenameHabitByID(ctx, habitID, "Workout")
+	require.NoError(t, err)
+
+	// Verify new name
+	today := time.Now()
+	from := today.AddDate(0, 0, -30)
+	details, err := service.InspectHabitByID(ctx, habitID, from, today, today)
+	require.NoError(t, err)
+	assert.Equal(t, "Workout", details.Name)
+}
+
+func TestHabitService_RenameHabit_NotFound(t *testing.T) {
+	service := setupHabitService(t)
+	ctx := context.Background()
+
+	err := service.RenameHabit(ctx, "NonExistent", "NewName")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
## Summary

- Add `habit inspect` command to see log IDs for corrections
- Add `habit delete-log` to remove specific log entries
- Add `habit rename` to fix habit naming mistakes
- Add `habit undo` as shortcut to remove most recent log
- Support `#id` syntax in `habit log` command
- Remove habit IDs from default view (cleaner output)

Fixes #5

## New Commands

| Command | Purpose |
|---------|---------|
| `habit inspect <name>` | Show logs with IDs (default 30 days) |
| `habit inspect <name> --from <date>` | Filter by date range |
| `habit delete-log <id>` | Delete specific log entry |
| `habit rename <old> <new>` | Rename a habit |
| `habit undo <name>` | Delete most recent log |
| `habit log #1` | Log by habit ID |

## Architecture

All business logic in service layer (reusable by web API):
- `InspectHabit`, `InspectHabitByID`
- `DeleteLog`
- `RenameHabit`, `RenameHabitByID`
- `UndoLastLog`, `UndoLastLogByID`
- `LogHabitByID`, `LogHabitByIDForDate`

## Test plan

- [x] 99 tests passing (15 new tests)
- [x] golangci-lint clean
- [x] Manual testing of all new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)