### PR TITLE
feat(cli): change ls to show last 7 days, add today command

### DIFF
--- a/cmd/bujo/cmd/ls.go
+++ b/cmd/bujo/cmd/ls.go
@@ -8,21 +8,59 @@ import (
 	"github.com/typingincolor/bujo/internal/adapter/cli"
 )
 
+var (
+	lsFrom string
+	lsTo   string
+)
+
 var lsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "Display daily agenda",
-	Long:  `Display today's entries, including overdue tasks and the current location.`,
+	Short: "Display entries for the last 7 days",
+	Long: `Display entries for the last 7 days, including overdue tasks.
+
+Use --from and --to to specify a custom date range.
+
+Examples:
+  bujo ls
+  bujo ls --from yesterday
+  bujo ls --from "last monday" --to today
+  bujo ls --from 2026-01-01 --to 2026-01-07`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		agenda, err := bujoService.GetDailyAgenda(cmd.Context(), time.Now())
-		if err != nil {
-			return fmt.Errorf("failed to get agenda: %w", err)
+		today := time.Now()
+		todayStart := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+
+		// Default: last 7 days
+		from := todayStart.AddDate(0, 0, -6)
+		to := todayStart
+
+		if lsFrom != "" {
+			parsed, err := parsePastDate(lsFrom)
+			if err != nil {
+				return err
+			}
+			from = parsed
 		}
 
-		fmt.Print(cli.RenderDailyAgenda(agenda))
+		if lsTo != "" {
+			parsed, err := parsePastDate(lsTo)
+			if err != nil {
+				return err
+			}
+			to = parsed
+		}
+
+		agenda, err := bujoService.GetMultiDayAgenda(cmd.Context(), from, to)
+		if err != nil {
+			return fmt.Errorf("failed to get entries: %w", err)
+		}
+
+		fmt.Print(cli.RenderMultiDayAgenda(agenda))
 		return nil
 	},
 }
 
 func init() {
+	lsCmd.Flags().StringVar(&lsFrom, "from", "", "Start date (e.g., 'yesterday', 'last monday', '2026-01-01')")
+	lsCmd.Flags().StringVar(&lsTo, "to", "", "End date (e.g., 'today', '2026-01-07')")
 	rootCmd.AddCommand(lsCmd)
 }

--- a/cmd/bujo/cmd/today.go
+++ b/cmd/bujo/cmd/today.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/typingincolor/bujo/internal/adapter/cli"
+)
+
+var todayCmd = &cobra.Command{
+	Use:   "today",
+	Short: "Display today's entries",
+	Long:  `Display today's entries, including overdue tasks and the current location.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agenda, err := bujoService.GetDailyAgenda(cmd.Context(), time.Now())
+		if err != nil {
+			return fmt.Errorf("failed to get agenda: %w", err)
+		}
+
+		fmt.Print(cli.RenderDailyAgenda(agenda))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(todayCmd)
+}

--- a/internal/adapter/cli/renderer.go
+++ b/internal/adapter/cli/renderer.go
@@ -56,6 +56,38 @@ func RenderDailyAgenda(agenda *service.DailyAgenda) string {
 	return sb.String()
 }
 
+func RenderMultiDayAgenda(agenda *service.MultiDayAgenda) string {
+	var sb strings.Builder
+
+	// Overdue section
+	if len(agenda.Overdue) > 0 {
+		sb.WriteString(fmt.Sprintf("%s\n", Red(Bold("OVERDUE"))))
+		for _, entry := range agenda.Overdue {
+			sb.WriteString(renderEntry(entry, 0, true))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Each day
+	for _, day := range agenda.Days {
+		dateStr := day.Date.Format("Monday, Jan 2")
+		if day.Location != nil {
+			sb.WriteString(fmt.Sprintf("📅 %s | 📍 %s\n", Cyan(Bold(dateStr)), Yellow(*day.Location)))
+		} else {
+			sb.WriteString(fmt.Sprintf("📅 %s\n", Cyan(Bold(dateStr))))
+		}
+
+		if len(day.Entries) > 0 {
+			renderEntryTree(&sb, day.Entries, 0)
+		} else {
+			sb.WriteString(Dimmed("  No entries\n"))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
 func renderEntryTree(sb *strings.Builder, entries []domain.Entry, depth int) {
 	// Build parent-child map
 	children := make(map[int64][]domain.Entry)

--- a/internal/repository/sqlite/entry_repository.go
+++ b/internal/repository/sqlite/entry_repository.go
@@ -60,6 +60,23 @@ func (r *EntryRepository) GetByDate(ctx context.Context, date time.Time) ([]doma
 	return r.scanEntries(rows)
 }
 
+func (r *EntryRepository) GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error) {
+	fromStr := from.Format("2006-01-02")
+	toStr := to.Format("2006-01-02")
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, type, content, parent_id, depth, location, scheduled_date, created_at
+		FROM entries WHERE scheduled_date >= ? AND scheduled_date <= ?
+		ORDER BY scheduled_date, created_at
+	`, fromStr, toStr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	return r.scanEntries(rows)
+}
+
 func (r *EntryRepository) GetOverdue(ctx context.Context, date time.Time) ([]domain.Entry, error) {
 	dateStr := date.Format("2006-01-02")
 

--- a/internal/service/bujo.go
+++ b/internal/service/bujo.go
@@ -12,6 +12,7 @@ type EntryRepository interface {
 	Insert(ctx context.Context, entry domain.Entry) (int64, error)
 	GetByID(ctx context.Context, id int64) (*domain.Entry, error)
 	GetByDate(ctx context.Context, date time.Time) ([]domain.Entry, error)
+	GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error)
 	GetOverdue(ctx context.Context, date time.Time) ([]domain.Entry, error)
 	GetWithChildren(ctx context.Context, id int64) ([]domain.Entry, error)
 	GetChildren(ctx context.Context, parentID int64) ([]domain.Entry, error)
@@ -87,6 +88,17 @@ type DailyAgenda struct {
 	Today    []domain.Entry
 }
 
+type DayEntries struct {
+	Date     time.Time
+	Location *string
+	Entries  []domain.Entry
+}
+
+type MultiDayAgenda struct {
+	Overdue []domain.Entry
+	Days    []DayEntries
+}
+
 func (s *BujoService) GetDailyAgenda(ctx context.Context, date time.Time) (*DailyAgenda, error) {
 	agenda := &DailyAgenda{
 		Date: date,
@@ -114,6 +126,56 @@ func (s *BujoService) GetDailyAgenda(ctx context.Context, date time.Time) (*Dail
 		return nil, err
 	}
 	agenda.Today = today
+
+	return agenda, nil
+}
+
+func (s *BujoService) GetMultiDayAgenda(ctx context.Context, from, to time.Time) (*MultiDayAgenda, error) {
+	agenda := &MultiDayAgenda{}
+
+	// Get overdue entries (before the from date)
+	overdue, err := s.entryRepo.GetOverdue(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	agenda.Overdue = overdue
+
+	// Get all entries in the range
+	entries, err := s.entryRepo.GetByDateRange(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get locations for the range
+	locations, err := s.dayCtxRepo.GetRange(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+	locationMap := make(map[string]*string)
+	for _, loc := range locations {
+		dateKey := loc.Date.Format("2006-01-02")
+		locationMap[dateKey] = loc.Location
+	}
+
+	// Group entries by date
+	entryMap := make(map[string][]domain.Entry)
+	for _, entry := range entries {
+		if entry.ScheduledDate != nil {
+			dateKey := entry.ScheduledDate.Format("2006-01-02")
+			entryMap[dateKey] = append(entryMap[dateKey], entry)
+		}
+	}
+
+	// Build days array from from to to (inclusive)
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		dateKey := d.Format("2006-01-02")
+		day := DayEntries{
+			Date:     d,
+			Location: locationMap[dateKey],
+			Entries:  entryMap[dateKey],
+		}
+		agenda.Days = append(agenda.Days, day)
+	}
 
 	return agenda, nil
 }


### PR DESCRIPTION
## Summary

Fixes #8

- `bujo ls` now shows last 7 days (was: today only)
- `bujo ls --from X --to Y` supports custom date ranges  
- `bujo today` shows single day view (old ls behavior)

## Implementation

- Add `GetByDateRange` to EntryRepository
- Add `GetMultiDayAgenda` to BujoService with TDD (4 tests)
- Add `RenderMultiDayAgenda` to renderer

## Test plan

- [x] 4 new service tests for GetMultiDayAgenda
- [x] All existing tests pass
- [x] Manual testing of ls and today commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)