### PR TITLE
fix: add date validation and append entry IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ bujo ls --from "last monday" --to today
 bujo ls --from 2026-01-01 --to 2026-01-07
 ```
 
+**Note:** `--from` must be before or equal to `--to`.
+
 #### `bujo today`
 
 Display today's entries with overdue tasks and location.
@@ -100,9 +102,9 @@ Display today's entries with overdue tasks and location.
 📅 Tuesday, Jan 6, 2026 | 📍 Home Office
 ---------------------------------------------------------
 TODAY
-  1 . Buy groceries
-  2 . Finish report
-  └──   3 - Remember to include Q4 data
+. Buy groceries (1)
+. Finish report (2)
+└── - Remember to include Q4 data (3)
 ---------------------------------------------------------
 ```
 

--- a/cmd/bujo/cmd/habit_inspect.go
+++ b/cmd/bujo/cmd/habit_inspect.go
@@ -56,6 +56,10 @@ Examples:
 			to = parsed
 		}
 
+		if err := validateDateRange(from, to); err != nil {
+			return err
+		}
+
 		var details *service.HabitDetails
 
 		if isID {

--- a/cmd/bujo/cmd/helpers.go
+++ b/cmd/bujo/cmd/helpers.go
@@ -43,6 +43,13 @@ func parsePastDate(s string) (time.Time, error) {
 	return parsed, nil
 }
 
+func validateDateRange(from, to time.Time) error {
+	if from.After(to) {
+		return fmt.Errorf("--from date must be before --to date")
+	}
+	return nil
+}
+
 func parseFutureDate(s string) (time.Time, error) {
 	now := time.Now()
 

--- a/cmd/bujo/cmd/helpers_test.go
+++ b/cmd/bujo/cmd/helpers_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateDateRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    time.Time
+		to      time.Time
+		wantErr bool
+	}{
+		{
+			name:    "valid range",
+			from:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			to:      time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "same day is valid",
+			from:    time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			to:      time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "from after to is invalid",
+			from:    time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC),
+			to:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDateRange(tt.from, tt.to)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateDateRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/bujo/cmd/ls.go
+++ b/cmd/bujo/cmd/ls.go
@@ -49,6 +49,10 @@ Examples:
 			to = parsed
 		}
 
+		if err := validateDateRange(from, to); err != nil {
+			return err
+		}
+
 		agenda, err := bujoService.GetMultiDayAgenda(cmd.Context(), from, to)
 		if err != nil {
 			return fmt.Errorf("failed to get entries: %w", err)

--- a/cmd/bujo/cmd/view.go
+++ b/cmd/bujo/cmd/view.go
@@ -81,7 +81,7 @@ func renderViewEntry(sb *strings.Builder, entry domain.Entry, children map[int64
 	}
 
 	symbol := entry.Type.Symbol()
-	idStr := fmt.Sprintf("%3d", entry.ID)
+	idStr := fmt.Sprintf("(%d)", entry.ID)
 	content := entry.Content
 
 	// Highlight the requested entry
@@ -102,7 +102,7 @@ func renderViewEntry(sb *strings.Builder, entry domain.Entry, children map[int64
 		}
 	}
 
-	fmt.Fprintf(sb, "%s%s%s %s %s\n", indent, prefix, idStr, symbol, content)
+	fmt.Fprintf(sb, "%s%s%s %s %s\n", indent, prefix, symbol, content, idStr)
 
 	for _, child := range children[entry.ID] {
 		renderViewEntry(sb, child, children, depth+1, highlightID)

--- a/cmd/bujo/cmd/work_inspect.go
+++ b/cmd/bujo/cmd/work_inspect.go
@@ -48,6 +48,10 @@ Examples:
 			to = parsed
 		}
 
+		if err := validateDateRange(from, to); err != nil {
+			return err
+		}
+
 		history, err := bujoService.GetLocationHistory(cmd.Context(), from, to)
 		if err != nil {
 			return fmt.Errorf("failed to get location history: %w", err)

--- a/internal/adapter/cli/renderer.go
+++ b/internal/adapter/cli/renderer.go
@@ -123,7 +123,7 @@ func renderEntry(entry domain.Entry, depth int, overdue bool) string {
 
 	symbol := entry.Type.Symbol()
 	content := entry.Content
-	idStr := fmt.Sprintf("%3d", entry.ID)
+	idStr := fmt.Sprintf("(%d)", entry.ID)
 
 	// Color based on type
 	switch entry.Type {
@@ -142,7 +142,7 @@ func renderEntry(entry domain.Entry, depth int, overdue bool) string {
 		idStr = Red(idStr)
 	}
 
-	return fmt.Sprintf("%s%s%s %s %s\n", indent, treePrefix, idStr, symbol, content)
+	return fmt.Sprintf("%s%s%s %s %s\n", indent, treePrefix, symbol, content, idStr)
 }
 
 func RenderHabitTracker(status *service.TrackerStatus) string {


### PR DESCRIPTION
## Summary
- Add `validateDateRange(from, to)` helper with tests (Fixes #10)
- Apply validation to `ls`, `habit inspect`, and `work inspect` commands
- Change entry ID display from `1 . Buy groceries` to `. Buy groceries (1)` (Fixes #11)

## Test plan
- [x] Unit tests for validateDateRange helper
- [x] Manually tested `bujo ls --from 2026-01-07 --to 2026-01-01` shows error
- [x] Manually tested `bujo today` shows new ID format

🤖 Generated with [Claude Code](https://claude.com/claude-code)