### PR TITLE
feat(tui): add entry management (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,10 @@ j/k: move  space: done  d: delete  q: quit  ?: help
 | `g` | Jump to top |
 | `G` | Jump to bottom |
 | `Space` | Toggle done/undone |
+| `e` | Edit entry content |
+| `a` | Add new entry |
+| `A` | Add child entry (under selected) |
+| `m` | Migrate task to future date |
 | `d` | Delete entry |
 | `?` | Toggle help |
 | `q` | Quit |

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/typingincolor/bujo
 go 1.25
 
 require (
+	github.com/charmbracelet/bubbles v0.21.0
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/spf13/cobra v1.10.2
@@ -12,11 +15,9 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v0.21.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
+github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
 github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -12,6 +16,8 @@ github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -3,16 +3,20 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type KeyMap struct {
-	Up      key.Binding
-	Down    key.Binding
-	Top     key.Binding
-	Bottom  key.Binding
-	Done    key.Binding
-	Delete  key.Binding
-	Confirm key.Binding
-	Cancel  key.Binding
-	Quit    key.Binding
-	Help    key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Top      key.Binding
+	Bottom   key.Binding
+	Done     key.Binding
+	Delete   key.Binding
+	Edit     key.Binding
+	Add      key.Binding
+	AddChild key.Binding
+	Migrate  key.Binding
+	Confirm  key.Binding
+	Cancel   key.Binding
+	Quit     key.Binding
+	Help     key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -41,6 +45,22 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("d"),
 			key.WithHelp("d", "delete"),
 		),
+		Edit: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "edit"),
+		),
+		Add: key.NewBinding(
+			key.WithKeys("a"),
+			key.WithHelp("a", "add"),
+		),
+		AddChild: key.NewBinding(
+			key.WithKeys("A"),
+			key.WithHelp("A", "add child"),
+		),
+		Migrate: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "migrate"),
+		),
 		Confirm: key.NewBinding(
 			key.WithKeys("y", "Y"),
 			key.WithHelp("y", "confirm"),
@@ -61,13 +81,13 @@ func DefaultKeyMap() KeyMap {
 }
 
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Done, k.Delete, k.Quit, k.Help}
+	return []key.Binding{k.Up, k.Down, k.Done, k.Edit, k.Add, k.Migrate, k.Delete, k.Quit, k.Help}
 }
 
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Top, k.Bottom},
-		{k.Done, k.Delete},
+		{k.Done, k.Edit, k.Add, k.AddChild, k.Migrate, k.Delete},
 		{k.Quit, k.Help},
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/typingincolor/bujo/internal/domain"
 	"github.com/typingincolor/bujo/internal/service"
@@ -17,6 +18,9 @@ type Model struct {
 	entries     []EntryItem
 	selectedIdx int
 	confirmMode confirmState
+	editMode    editState
+	addMode     addState
+	migrateMode migrateState
 	help        help.Model
 	keyMap      KeyMap
 	width       int
@@ -28,6 +32,25 @@ type confirmState struct {
 	active      bool
 	entryID     int64
 	hasChildren bool
+}
+
+type editState struct {
+	active  bool
+	entryID int64
+	input   textinput.Model
+}
+
+type addState struct {
+	active   bool
+	asChild  bool
+	parentID *int64
+	input    textinput.Model
+}
+
+type migrateState struct {
+	active  bool
+	entryID int64
+	input   textinput.Model
 }
 
 type EntryItem struct {
@@ -89,6 +112,11 @@ func (m Model) flattenAgenda(agenda *service.MultiDayAgenda) []EntryItem {
 	}
 
 	return items
+}
+
+func (m Model) getTodayDate() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 }
 
 func (m Model) flattenEntries(entries []domain.Entry, header string, isOverdue bool) []EntryItem {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2,10 +2,15 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/tj/go-naturaldate"
 	"github.com/typingincolor/bujo/internal/domain"
+	"github.com/typingincolor/bujo/internal/service"
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -40,6 +45,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.editMode.active {
+			return m.handleEditMode(msg)
+		}
+		if m.addMode.active {
+			return m.handleAddMode(msg)
+		}
+		if m.migrateMode.active {
+			return m.handleMigrateMode(msg)
+		}
 		if m.confirmMode.active {
 			return m.handleConfirmMode(msg)
 		}
@@ -82,6 +96,75 @@ func (m Model) handleNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keyMap.Delete):
 		return m, m.initiateDeleteCmd()
 
+	case key.Matches(msg, m.keyMap.Edit):
+		if len(m.entries) == 0 {
+			return m, nil
+		}
+		entry := m.entries[m.selectedIdx].Entry
+		ti := textinput.New()
+		ti.SetValue(entry.Content)
+		ti.Focus()
+		ti.CharLimit = 256
+		ti.Width = m.width - 10
+		m.editMode = editState{
+			active:  true,
+			entryID: entry.ID,
+			input:   ti,
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keyMap.Add):
+		ti := textinput.New()
+		ti.Placeholder = ". task, - note, o event"
+		ti.Focus()
+		ti.CharLimit = 256
+		ti.Width = m.width - 10
+		m.addMode = addState{
+			active:  true,
+			asChild: false,
+			input:   ti,
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keyMap.AddChild):
+		if len(m.entries) == 0 {
+			return m, nil
+		}
+		entry := m.entries[m.selectedIdx].Entry
+		ti := textinput.New()
+		ti.Placeholder = ". task, - note, o event"
+		ti.Focus()
+		ti.CharLimit = 256
+		ti.Width = m.width - 10
+		parentID := entry.ID
+		m.addMode = addState{
+			active:   true,
+			asChild:  true,
+			parentID: &parentID,
+			input:    ti,
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keyMap.Migrate):
+		if len(m.entries) == 0 {
+			return m, nil
+		}
+		entry := m.entries[m.selectedIdx].Entry
+		if entry.Type != domain.EntryTypeTask {
+			return m, nil
+		}
+		ti := textinput.New()
+		ti.Placeholder = "tomorrow, next monday, 2026-01-15"
+		ti.Focus()
+		ti.CharLimit = 64
+		ti.Width = m.width - 10
+		m.migrateMode = migrateState{
+			active:  true,
+			entryID: entry.ID,
+			input:   ti,
+		}
+		return m, nil
+
 	case key.Matches(msg, m.keyMap.Help):
 		m.help.ShowAll = !m.help.ShowAll
 		return m, nil
@@ -103,6 +186,116 @@ func (m Model) handleConfirmMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m Model) handleEditMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.editMode.active = false
+		return m, nil
+
+	case tea.KeyEnter:
+		entryID := m.editMode.entryID
+		newContent := m.editMode.input.Value()
+		m.editMode.active = false
+		return m, m.editEntryCmd(entryID, newContent)
+	}
+
+	var cmd tea.Cmd
+	m.editMode.input, cmd = m.editMode.input.Update(msg)
+	return m, cmd
+}
+
+func (m Model) editEntryCmd(id int64, content string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		if err := m.bujoService.EditEntry(ctx, id, content); err != nil {
+			return errMsg{err}
+		}
+		return entryUpdatedMsg{id}
+	}
+}
+
+func (m Model) handleAddMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.addMode.active = false
+		return m, nil
+
+	case tea.KeyEnter:
+		content := m.addMode.input.Value()
+		if content == "" {
+			m.addMode.active = false
+			return m, nil
+		}
+		parentID := m.addMode.parentID
+		m.addMode.active = false
+		return m, m.addEntryCmd(content, parentID)
+	}
+
+	var cmd tea.Cmd
+	m.addMode.input, cmd = m.addMode.input.Update(msg)
+	return m, cmd
+}
+
+func (m Model) addEntryCmd(content string, parentID *int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		today := m.getTodayDate()
+		opts := service.LogEntriesOptions{Date: today}
+		ids, err := m.bujoService.LogEntries(ctx, content, opts)
+		if err != nil {
+			return errMsg{err}
+		}
+		if len(ids) == 0 {
+			return entryUpdatedMsg{0}
+		}
+
+		if parentID != nil {
+			moveOpts := service.MoveOptions{NewParentID: parentID}
+			if err := m.bujoService.MoveEntry(ctx, ids[0], moveOpts); err != nil {
+				return errMsg{err}
+			}
+		}
+		return entryUpdatedMsg{ids[0]}
+	}
+}
+
+func (m Model) handleMigrateMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.migrateMode.active = false
+		return m, nil
+
+	case tea.KeyEnter:
+		dateStr := m.migrateMode.input.Value()
+		if dateStr == "" {
+			m.migrateMode.active = false
+			return m, nil
+		}
+		entryID := m.migrateMode.entryID
+		m.migrateMode.active = false
+		return m, m.migrateEntryCmd(entryID, dateStr)
+	}
+
+	var cmd tea.Cmd
+	m.migrateMode.input, cmd = m.migrateMode.input.Update(msg)
+	return m, cmd
+}
+
+func (m Model) migrateEntryCmd(id int64, dateStr string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		toDate, err := parseDate(dateStr)
+		if err != nil {
+			return errMsg{err}
+		}
+		newID, err := m.bujoService.MigrateEntry(ctx, id, toDate)
+		if err != nil {
+			return errMsg{err}
+		}
+		return entryUpdatedMsg{newID}
+	}
 }
 
 func (m Model) toggleDoneCmd() tea.Cmd {
@@ -160,4 +353,19 @@ func (m Model) deleteWithChildrenCmd(id int64) tea.Cmd {
 		}
 		return entryDeletedMsg{id}
 	}
+}
+
+func parseDate(s string) (time.Time, error) {
+	now := time.Now()
+
+	if parsed, err := time.Parse("2006-01-02", s); err == nil {
+		return parsed, nil
+	}
+
+	parsed, err := naturaldate.Parse(s, now, naturaldate.WithDirection(naturaldate.Future))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid date: %s", s)
+	}
+
+	return parsed, nil
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -46,7 +46,19 @@ func (m Model) View() string {
 		}
 	}
 
-	if m.confirmMode.active {
+	if m.editMode.active {
+		sb.WriteString("\n")
+		sb.WriteString(m.renderEditInput())
+		sb.WriteString("\n")
+	} else if m.addMode.active {
+		sb.WriteString("\n")
+		sb.WriteString(m.renderAddInput())
+		sb.WriteString("\n")
+	} else if m.migrateMode.active {
+		sb.WriteString("\n")
+		sb.WriteString(m.renderMigrateInput())
+		sb.WriteString("\n")
+	} else if m.confirmMode.active {
 		sb.WriteString("\n")
 		sb.WriteString(m.renderConfirmDialog())
 		sb.WriteString("\n")
@@ -93,4 +105,32 @@ func (m Model) renderConfirmDialog() string {
   n - No, cancel`
 
 	return ConfirmStyle.Render(dialog)
+}
+
+func (m Model) renderEditInput() string {
+	var sb strings.Builder
+	sb.WriteString("Edit entry:\n")
+	sb.WriteString(m.editMode.input.View())
+	sb.WriteString("\n\nEnter to save, Esc to cancel")
+	return ConfirmStyle.Render(sb.String())
+}
+
+func (m Model) renderAddInput() string {
+	var sb strings.Builder
+	if m.addMode.asChild {
+		sb.WriteString("Add child entry:\n")
+	} else {
+		sb.WriteString("Add entry:\n")
+	}
+	sb.WriteString(m.addMode.input.View())
+	sb.WriteString("\n\nEnter to add, Esc to cancel")
+	return ConfirmStyle.Render(sb.String())
+}
+
+func (m Model) renderMigrateInput() string {
+	var sb strings.Builder
+	sb.WriteString("Migrate to date:\n")
+	sb.WriteString(m.migrateMode.input.View())
+	sb.WriteString("\n\nEnter to migrate, Esc to cancel")
+	return ConfirmStyle.Render(sb.String())
 }


### PR DESCRIPTION
## Summary
- Add inline editing with `e` key
- Add new entries with `a` key
- Add child entries with `A` key (under selected entry)
- Migrate tasks to future dates with `m` key (supports natural language dates)

## Implementation
- New modes: `editMode`, `addMode`, `migrateMode`
- Uses existing BujoService methods: `EditEntry`, `LogEntries`, `MoveEntry`, `MigrateEntry`
- Natural language date parsing for migrate (tomorrow, next monday, etc.)
- 31 tests for TUI package

## Test plan
- [x] All existing tests pass
- [x] New tests for edit, add, migrate modes
- [ ] Manual testing with `bujo tui`

## Files changed
- `internal/tui/model.go` - New mode state structs
- `internal/tui/keymap.go` - New keybindings (e, a, A, m)
- `internal/tui/update.go` - Mode handlers and commands
- `internal/tui/view.go` - Input rendering for each mode
- `internal/tui/tui_test.go` - Tests for new modes
- `README.md` - Document new keybindings

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)