### PR TITLE
feat: improve habit CLI usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,15 +336,18 @@ Gym (3 day streak)
   1/1 today | 43% completion
 ```
 
-#### `bujo habit log <name> [count]`
+#### `bujo habit log <name|#id> [count]`
 
-Log a habit completion. Creates the habit if it doesn't exist.
+Log a habit completion. If the habit doesn't exist, you'll be prompted to create it.
+
+**Important:** To reference a habit by ID, use `#` prefix (e.g., `#1`). Without `#`, the argument is treated as a habit name.
 
 ```bash
 bujo habit log Gym
 bujo habit log Water 8
 bujo habit log Gym --date yesterday
-bujo habit log #1 5              # By ID with count
+bujo habit log "#1" 5            # By ID with count (quote the #)
+bujo habit log NewHabit --yes    # Create without prompting
 ```
 
 #### `bujo habit set-goal <name|#id> <goal>`
@@ -390,6 +393,16 @@ Delete a specific log entry by ID (use `habit inspect` to see IDs).
 
 ```bash
 bujo habit delete-log 42
+```
+
+#### `bujo habit delete <name|#id>`
+
+Delete a habit and all its logs. Requires confirmation unless `--force` is used.
+
+```bash
+bujo habit delete Gym
+bujo habit delete "#1"
+bujo habit delete OldHabit --force    # Skip confirmation
 ```
 
 ### List Management

--- a/cmd/bujo/cmd/habit_delete.go
+++ b/cmd/bujo/cmd/habit_delete.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var habitDeleteForce bool
+
+var habitDeleteCmd = &cobra.Command{
+	Use:   "delete <habit-name|#id>",
+	Short: "Delete a habit and all its logs",
+	Long: `Delete a habit and all its log entries.
+
+This is a destructive action - all logs for this habit will be permanently deleted.
+You will be prompted to confirm unless --force is used.
+
+Examples:
+  bujo habit delete Gym
+  bujo habit delete #1
+  bujo habit delete "Morning Run" --force`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, id, isID, err := parseHabitNameOrID(args[0])
+		if err != nil {
+			return err
+		}
+
+		displayName := args[0]
+
+		if !isID && isPureNumber(args[0]) && !habitDeleteForce {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+				displayName = "#" + args[0]
+			}
+		}
+
+		if !habitDeleteForce {
+			fmt.Printf("Delete habit '%s' and all its logs? This cannot be undone.\n", displayName)
+			fmt.Print("Type 'yes' to confirm: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(input)
+
+			if confirm != "yes" {
+				fmt.Fprintln(os.Stderr, "Cancelled")
+				return nil
+			}
+		}
+
+		if isID {
+			err = habitService.DeleteHabitByID(cmd.Context(), id)
+		} else {
+			err = habitService.DeleteHabit(cmd.Context(), name)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to delete habit: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ Deleted habit '%s'\n", displayName)
+		return nil
+	},
+}
+
+func init() {
+	habitDeleteCmd.Flags().BoolVarP(&habitDeleteForce, "force", "f", false, "Delete without prompting")
+	habitCmd.AddCommand(habitDeleteCmd)
+}

--- a/cmd/bujo/cmd/habit_inspect.go
+++ b/cmd/bujo/cmd/habit_inspect.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,6 +36,18 @@ Examples:
 		name, id, isID, err := parseHabitNameOrID(args[0])
 		if err != nil {
 			return err
+		}
+
+		if !isID && isPureNumber(args[0]) {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+			}
 		}
 
 		today := time.Now()

--- a/cmd/bujo/cmd/habit_log.go
+++ b/cmd/bujo/cmd/habit_log.go
@@ -1,21 +1,25 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var habitLogDate string
+var habitLogYes bool
 
 var habitLogCmd = &cobra.Command{
 	Use:   "log <habit-name|#id> [count]",
 	Short: "Log a habit completion",
 	Long: `Log a habit completion for today or a specific date.
 
-If the habit doesn't exist, it will be created automatically.
+If the habit doesn't exist, you will be prompted to create it.
+Use --yes to skip the confirmation and create automatically.
 Count defaults to 1 if not specified.
 Use #<id> to log by habit ID (shown in bujo habit output).
 
@@ -26,7 +30,8 @@ Examples:
   bujo habit log #1              (log by ID)
   bujo habit log #2 5            (log by ID with count)
   bujo habit log Gym --date yesterday
-  bujo habit log Gym -d 2026-01-05`,
+  bujo habit log Gym -d 2026-01-05
+  bujo habit log NewHabit --yes  (create without prompting)`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, id, isID, err := parseHabitNameOrID(args[0])
@@ -47,9 +52,42 @@ Examples:
 			return err
 		}
 
+		displayName := args[0]
+
+		if !isID && isPureNumber(args[0]) && !habitLogYes {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+				displayName = "#" + args[0]
+			}
+		}
+
 		if isID {
 			err = habitService.LogHabitByIDForDate(cmd.Context(), id, count, logDate)
 		} else {
+			var exists bool
+			exists, err = habitService.HabitExists(cmd.Context(), name)
+			if err != nil {
+				return fmt.Errorf("failed to check habit: %w", err)
+			}
+
+			if !exists && !habitLogYes {
+				fmt.Printf("Habit '%s' does not exist. Create it? [y/N]: ", name)
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				confirm := strings.TrimSpace(strings.ToLower(input))
+
+				if confirm != "y" && confirm != "yes" {
+					fmt.Fprintln(os.Stderr, "Cancelled")
+					return nil
+				}
+			}
+
 			err = habitService.LogHabitForDate(cmd.Context(), name, count, logDate)
 		}
 
@@ -57,7 +95,6 @@ Examples:
 			return fmt.Errorf("failed to log habit: %w", err)
 		}
 
-		displayName := args[0]
 		if habitLogDate != "" {
 			fmt.Fprintf(os.Stderr, "✓ Logged: %s for %s\n", displayName, habitLogDate)
 		} else if count == 1 {
@@ -72,5 +109,6 @@ Examples:
 
 func init() {
 	habitLogCmd.Flags().StringVarP(&habitLogDate, "date", "d", "", "Date to log for (e.g., 'yesterday', 'last monday', '2 weeks ago')")
+	habitLogCmd.Flags().BoolVarP(&habitLogYes, "yes", "y", false, "Create habit without prompting if it doesn't exist")
 	habitCmd.AddCommand(habitLogCmd)
 }

--- a/cmd/bujo/cmd/habit_rename.go
+++ b/cmd/bujo/cmd/habit_rename.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -26,6 +29,21 @@ Examples:
 			return err
 		}
 
+		displayName := args[0]
+
+		if !isID && isPureNumber(args[0]) {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+				displayName = "#" + args[0]
+			}
+		}
+
 		if isID {
 			err = habitService.RenameHabitByID(cmd.Context(), id, newName)
 		} else {
@@ -36,7 +54,7 @@ Examples:
 			return fmt.Errorf("failed to rename habit: %w", err)
 		}
 
-		fmt.Fprintf(os.Stderr, "✓ Renamed %s to %s\n", args[0], newName)
+		fmt.Fprintf(os.Stderr, "✓ Renamed %s to %s\n", displayName, newName)
 		return nil
 	},
 }

--- a/cmd/bujo/cmd/habit_set_goal.go
+++ b/cmd/bujo/cmd/habit_set_goal.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -31,6 +33,21 @@ Examples:
 			return err
 		}
 
+		displayName := args[0]
+
+		if !isID && isPureNumber(args[0]) {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+				displayName = "#" + args[0]
+			}
+		}
+
 		if isID {
 			err = habitService.SetHabitGoalByID(cmd.Context(), id, goal)
 		} else {
@@ -41,7 +58,7 @@ Examples:
 			return fmt.Errorf("failed to set goal: %w", err)
 		}
 
-		fmt.Fprintf(os.Stderr, "✓ Set goal for %s to %d/day\n", args[0], goal)
+		fmt.Fprintf(os.Stderr, "✓ Set goal for %s to %d/day\n", displayName, goal)
 		return nil
 	},
 }

--- a/cmd/bujo/cmd/habit_undo.go
+++ b/cmd/bujo/cmd/habit_undo.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -25,6 +28,21 @@ Examples:
 			return err
 		}
 
+		displayName := args[0]
+
+		if !isID && isPureNumber(args[0]) {
+			fmt.Printf("'%s' looks like an ID. Did you mean to use #%s? [y/N]: ", args[0], args[0])
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			confirm := strings.TrimSpace(strings.ToLower(input))
+
+			if confirm == "y" || confirm == "yes" {
+				id, _ = strconv.ParseInt(args[0], 10, 64)
+				isID = true
+				displayName = "#" + args[0]
+			}
+		}
+
 		if isID {
 			err = habitService.UndoLastLogByID(cmd.Context(), id)
 		} else {
@@ -35,7 +53,7 @@ Examples:
 			return fmt.Errorf("failed to undo habit: %w", err)
 		}
 
-		fmt.Fprintf(os.Stderr, "✓ Undid last log for: %s\n", args[0])
+		fmt.Fprintf(os.Stderr, "✓ Undid last log for: %s\n", displayName)
 		return nil
 	},
 }

--- a/cmd/bujo/cmd/helpers.go
+++ b/cmd/bujo/cmd/helpers.go
@@ -29,6 +29,14 @@ func parseHabitNameOrID(s string) (name string, id int64, isID bool, err error) 
 	return s, 0, false, nil
 }
 
+func isPureNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
+
 func parseListNameOrID(s string) (name string, id int64, isID bool, err error) {
 	if strings.HasPrefix(s, "#") {
 		id, err = strconv.ParseInt(s[1:], 10, 64)

--- a/internal/service/habit.go
+++ b/internal/service/habit.go
@@ -14,6 +14,7 @@ type HabitRepository interface {
 	GetByName(ctx context.Context, name string) (*domain.Habit, error)
 	GetAll(ctx context.Context) ([]domain.Habit, error)
 	Update(ctx context.Context, habit domain.Habit) error
+	Delete(ctx context.Context, id int64) error
 }
 
 type HabitLogRepository interface {
@@ -56,6 +57,14 @@ func (s *HabitService) getHabitByName(ctx context.Context, name string) (*domain
 		return nil, fmt.Errorf("habit not found: %s", name)
 	}
 	return habit, nil
+}
+
+func (s *HabitService) HabitExists(ctx context.Context, name string) (bool, error) {
+	habit, err := s.habitRepo.GetByName(ctx, name)
+	if err != nil {
+		return false, err
+	}
+	return habit != nil, nil
 }
 
 func (s *HabitService) LogHabit(ctx context.Context, name string, count int) error {
@@ -136,6 +145,24 @@ func (s *HabitService) DeleteLog(ctx context.Context, logID int64) error {
 	}
 
 	return s.logRepo.Delete(ctx, logID)
+}
+
+func (s *HabitService) DeleteHabit(ctx context.Context, name string) error {
+	habit, err := s.getHabitByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	return s.habitRepo.Delete(ctx, habit.ID)
+}
+
+func (s *HabitService) DeleteHabitByID(ctx context.Context, habitID int64) error {
+	habit, err := s.getHabitByID(ctx, habitID)
+	if err != nil {
+		return err
+	}
+
+	return s.habitRepo.Delete(ctx, habit.ID)
 }
 
 func (s *HabitService) RenameHabit(ctx context.Context, oldName, newName string) error {


### PR DESCRIPTION
## Summary
- Add `habit delete` command to delete habits and all their logs
- Add confirmation prompt when creating new habits via `habit log`
- Clarify documentation about `#` prefix requirement for habit IDs

## Changes
- **New command:** `bujo habit delete <name|#id>` with `--force` flag
- **Updated:** `bujo habit log` now prompts before creating new habits (use `--yes` to skip)
- **Service:** Added `HabitExists` and `DeleteHabit`/`DeleteHabitByID` methods
- **Docs:** Updated README with new commands and ID syntax clarification

## Test plan
- [x] `habit delete Gym` prompts for confirmation
- [x] `habit delete Gym --force` deletes without prompting
- [x] `habit log NewHabit` prompts to create if habit doesn't exist
- [x] `habit log NewHabit --yes` creates without prompting
- [x] `habit log "#1"` logs to habit by ID
- [x] All existing tests pass

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)