### PR TITLE
feat(tui): add collapse/expand functionality for parent entries

### DIFF
--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -237,17 +237,21 @@ func TestModel_FlattenAgenda_WithDays(t *testing.T) {
 func TestModel_FlattenAgenda_WithHierarchy(t *testing.T) {
 	model := New(nil)
 	parentID := int64(1)
+	parentEntityID := domain.EntityID("parent-entity-1")
 	agenda := &service.MultiDayAgenda{
 		Days: []service.DayEntries{
 			{
 				Date: time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC),
 				Entries: []domain.Entry{
-					{ID: 1, Content: "Parent", Type: domain.EntryTypeTask, ParentID: nil},
+					{ID: 1, EntityID: parentEntityID, Content: "Parent", Type: domain.EntryTypeTask, ParentID: nil},
 					{ID: 2, Content: "Child", Type: domain.EntryTypeNote, ParentID: &parentID},
 				},
 			},
 		},
 	}
+
+	// Expand the parent so we can test hierarchy
+	model.collapsed[parentEntityID] = false
 
 	result := model.flattenAgenda(agenda)
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -250,6 +250,23 @@ func (m Model) handleNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case msg.Type == tea.KeyEnter:
+		if len(m.entries) > 0 {
+			item := m.entries[m.selectedIdx]
+			if item.HasChildren {
+				entityID := item.Entry.EntityID
+				_, hasState := m.collapsed[entityID]
+				if hasState {
+					m.collapsed[entityID] = !m.collapsed[entityID]
+				} else {
+					m.collapsed[entityID] = false
+				}
+				m.entries = m.flattenAgenda(m.agenda)
+				return m.ensuredVisible(), nil
+			}
+		}
+		return m, nil
+
 	case key.Matches(msg, m.keyMap.Done):
 		return m, m.toggleDoneCmd()
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -402,15 +402,29 @@ func (m Model) renderEntry(item EntryItem) string {
 	entry := item.Entry
 	indent := strings.Repeat("  ", item.Indent)
 
+	collapseIndicator := ""
+	if item.HasChildren {
+		if item.HiddenChildCount > 0 {
+			collapseIndicator = "▶ "
+		} else {
+			collapseIndicator = "▼ "
+		}
+	}
+
 	symbol := entry.Type.Symbol()
 	prioritySymbol := entry.Priority.Symbol()
 	content := entry.Content
 
+	hiddenSuffix := ""
+	if item.HiddenChildCount > 0 {
+		hiddenSuffix = fmt.Sprintf(" [%d hidden]", item.HiddenChildCount)
+	}
+
 	var base string
 	if prioritySymbol != "" {
-		base = fmt.Sprintf("%s%s %s %s", indent, symbol, prioritySymbol, content)
+		base = fmt.Sprintf("%s%s%s %s %s%s", indent, collapseIndicator, symbol, prioritySymbol, content, hiddenSuffix)
 	} else {
-		base = fmt.Sprintf("%s%s %s", indent, symbol, content)
+		base = fmt.Sprintf("%s%s%s %s%s", indent, collapseIndicator, symbol, content, hiddenSuffix)
 	}
 
 	switch entry.Type {


### PR DESCRIPTION
## Summary

- Add collapse/expand functionality to parent entries in the TUI journal view
- Enter key toggles collapse state on entries with children
- Visual indicators: ▶ (collapsed with hidden count) / ▼ (expanded)
- All parents start collapsed by default for cleaner initial view
- Leaf entries show no indicator

## Changes

- **model.go**: Add `collapsed` map to track collapse state, modify `flattenEntries` to skip collapsed children and count hidden descendants
- **update.go**: Add Enter key handler to toggle collapse state
- **view.go**: Add arrow indicators and hidden count display
- **acceptance_test.go**: Add 5 comprehensive tests for collapse functionality
- **tui_test.go**: Update existing hierarchy test to account for default collapsed state

## Test plan

- [x] All new collapse tests pass
- [x] All existing tests pass
- [x] go vet passes
- [x] golangci-lint reports 0 issues

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)