### PR TITLE
feat(search): add search command with CLI and TUI support (#19)

### DIFF
--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -20,6 +20,7 @@ type EntryRepository interface {
 	DeleteWithChildren(ctx context.Context, id int64) error
 	GetHistory(ctx context.Context, entityID EntityID) ([]Entry, error)
 	GetAsOf(ctx context.Context, entityID EntityID, asOf time.Time) (*Entry, error)
+	Search(ctx context.Context, opts SearchOptions) ([]Entry, error)
 }
 
 type HabitRepository interface {

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -1,0 +1,34 @@
+package domain
+
+import "time"
+
+type SearchOptions struct {
+	Query    string
+	Type     *EntryType
+	DateFrom *time.Time
+	DateTo   *time.Time
+	Limit    int
+}
+
+func NewSearchOptions(query string) SearchOptions {
+	return SearchOptions{
+		Query: query,
+		Limit: 50,
+	}
+}
+
+func (o SearchOptions) WithType(t EntryType) SearchOptions {
+	o.Type = &t
+	return o
+}
+
+func (o SearchOptions) WithDateRange(from, to time.Time) SearchOptions {
+	o.DateFrom = &from
+	o.DateTo = &to
+	return o
+}
+
+func (o SearchOptions) WithLimit(limit int) SearchOptions {
+	o.Limit = limit
+	return o
+}

--- a/internal/repository/sqlite/entry_repository_test.go
+++ b/internal/repository/sqlite/entry_repository_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -599,4 +600,277 @@ func TestEntryRepository_GetAsOf_ReturnsCorrectVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "Original", result.Content)
+}
+
+func TestEntryRepository_Search_BasicContentSearch(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Buy groceries for dinner", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeNote, Content: "Meeting notes from project sync", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeEvent, Content: "Doctor appointment", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeTask, Content: "Grocery list updated", CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	opts := domain.NewSearchOptions("grocer")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	for _, r := range results {
+		assert.Contains(t, strings.ToLower(r.Content), "grocer", "All results should contain search term (case-insensitive)")
+	}
+}
+
+func TestEntryRepository_Search_CaseInsensitive(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Buy GROCERIES", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeNote, Content: "groceries list", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeTask, Content: "Groceries shopping", CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	opts := domain.NewSearchOptions("groceries")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 3, "Search should be case-insensitive")
+}
+
+func TestEntryRepository_Search_FilterByType(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Task with keyword", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeNote, Content: "Note with keyword", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeEvent, Content: "Event with keyword", CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	opts := domain.NewSearchOptions("keyword").WithType(domain.EntryTypeNote)
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, domain.EntryTypeNote, results[0].Type)
+}
+
+func TestEntryRepository_Search_FilterByDateRange(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	jan5 := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	jan10 := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	jan15 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Early meeting", ScheduledDate: &jan5, CreatedAt: time.Now()},
+		{Type: domain.EntryTypeTask, Content: "Middle meeting", ScheduledDate: &jan10, CreatedAt: time.Now()},
+		{Type: domain.EntryTypeTask, Content: "Late meeting", ScheduledDate: &jan15, CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	from := time.Date(2026, 1, 8, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 12, 0, 0, 0, 0, time.UTC)
+	opts := domain.NewSearchOptions("meeting").WithDateRange(from, to)
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "Middle meeting", results[0].Content)
+}
+
+func TestEntryRepository_Search_CombinedFilters(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	jan10 := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	jan15 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Project meeting", ScheduledDate: &jan10, CreatedAt: time.Now()},
+		{Type: domain.EntryTypeNote, Content: "Project notes", ScheduledDate: &jan10, CreatedAt: time.Now()},
+		{Type: domain.EntryTypeTask, Content: "Project deadline", ScheduledDate: &jan15, CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	from := time.Date(2026, 1, 8, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 12, 0, 0, 0, 0, time.UTC)
+	opts := domain.NewSearchOptions("project").WithType(domain.EntryTypeTask).WithDateRange(from, to)
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "Project meeting", results[0].Content)
+	assert.Equal(t, domain.EntryTypeTask, results[0].Type)
+}
+
+func TestEntryRepository_Search_NoResults(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entry := domain.Entry{
+		Type:      domain.EntryTypeTask,
+		Content:   "Something completely different",
+		CreatedAt: time.Now(),
+	}
+	_, err := repo.Insert(ctx, entry)
+	require.NoError(t, err)
+
+	opts := domain.NewSearchOptions("nonexistent")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 0)
+}
+
+func TestEntryRepository_Search_RespectsLimit(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		entry := domain.Entry{
+			Type:      domain.EntryTypeTask,
+			Content:   "Repeated task content",
+			CreatedAt: time.Now(),
+		}
+		_, err := repo.Insert(ctx, entry)
+		require.NoError(t, err)
+	}
+
+	opts := domain.NewSearchOptions("repeated").WithLimit(3)
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+func TestEntryRepository_Search_ExcludesDeletedEntries(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entry1 := domain.Entry{
+		Type:      domain.EntryTypeTask,
+		Content:   "Active searchable entry",
+		CreatedAt: time.Now(),
+	}
+	_, err := repo.Insert(ctx, entry1)
+	require.NoError(t, err)
+
+	entry2 := domain.Entry{
+		Type:      domain.EntryTypeTask,
+		Content:   "Deleted searchable entry",
+		CreatedAt: time.Now(),
+	}
+	id2, err := repo.Insert(ctx, entry2)
+	require.NoError(t, err)
+
+	err = repo.Delete(ctx, id2)
+	require.NoError(t, err)
+
+	opts := domain.NewSearchOptions("searchable")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1, "Search should exclude deleted entries")
+	assert.Equal(t, "Active searchable entry", results[0].Content)
+}
+
+func TestEntryRepository_Search_ExcludesOldVersions(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entry := domain.Entry{
+		Type:      domain.EntryTypeTask,
+		Content:   "Original searchable content",
+		CreatedAt: time.Now(),
+	}
+	id, err := repo.Insert(ctx, entry)
+	require.NoError(t, err)
+
+	inserted, err := repo.GetByID(ctx, id)
+	require.NoError(t, err)
+
+	inserted.Content = "Updated searchable content"
+	err = repo.Update(ctx, *inserted)
+	require.NoError(t, err)
+
+	opts := domain.NewSearchOptions("searchable")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 1, "Search should return only current version")
+	assert.Equal(t, "Updated searchable content", results[0].Content)
+}
+
+func TestEntryRepository_Search_IncludesCompletedEntries(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entries := []domain.Entry{
+		{Type: domain.EntryTypeTask, Content: "Active task with keyword", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeDone, Content: "Completed task with keyword", CreatedAt: time.Now()},
+		{Type: domain.EntryTypeCancelled, Content: "Cancelled task with keyword", CreatedAt: time.Now()},
+	}
+	for _, e := range entries {
+		_, err := repo.Insert(ctx, e)
+		require.NoError(t, err)
+	}
+
+	opts := domain.NewSearchOptions("keyword")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 3, "Search should include completed and cancelled entries")
+}
+
+func TestEntryRepository_Search_EmptyQuery(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewEntryRepository(db)
+	ctx := context.Background()
+
+	entry := domain.Entry{
+		Type:      domain.EntryTypeTask,
+		Content:   "Some content",
+		CreatedAt: time.Now(),
+	}
+	_, err := repo.Insert(ctx, entry)
+	require.NoError(t, err)
+
+	opts := domain.NewSearchOptions("")
+	results, err := repo.Search(ctx, opts)
+
+	require.NoError(t, err)
+	assert.Len(t, results, 0, "Empty query should return no results")
 }

--- a/internal/service/bujo.go
+++ b/internal/service/bujo.go
@@ -21,6 +21,7 @@ type EntryRepository interface {
 	DeleteWithChildren(ctx context.Context, id int64) error
 	GetDeleted(ctx context.Context) ([]domain.Entry, error)
 	Restore(ctx context.Context, entityID domain.EntityID) (int64, error)
+	Search(ctx context.Context, opts domain.SearchOptions) ([]domain.Entry, error)
 }
 
 type DayContextRepository interface {
@@ -648,4 +649,8 @@ func (s *BujoService) RestoreEntry(ctx context.Context, entityID domain.EntityID
 
 func (s *BujoService) ParseEntries(content string) ([]domain.Entry, error) {
 	return s.parser.Parse(content)
+}
+
+func (s *BujoService) SearchEntries(ctx context.Context, opts domain.SearchOptions) ([]domain.Entry, error) {
+	return s.entryRepo.Search(ctx, opts)
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -117,3 +117,8 @@ type summaryLoadedMsg struct {
 type summaryErrorMsg struct {
 	err error
 }
+
+type searchResultsMsg struct {
+	results []domain.Entry
+	query   string
+}


### PR DESCRIPTION
## Summary
- Add full-text search across entry content with LIKE-based case-insensitive matching
- CLI: `bujo search "query"` with `--from`, `--to`, `--type`, `--limit` flags for filtering by date range and entry type
- TUI: Search view (key 4) with live search, j/k navigation, and Enter to jump to entry's date in journal view

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)