### PR TITLE
feat(export): add data export and import commands (#20)

### DIFF
--- a/cmd/bujo/cmd/export.go
+++ b/cmd/bujo/cmd/export.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/typingincolor/bujo/internal/domain"
+	"github.com/typingincolor/bujo/internal/repository/sqlite"
+	"github.com/typingincolor/bujo/internal/service"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export all data to JSON",
+	Long: `Export all bujo data to JSON format for backup or migration.
+
+Examples:
+  bujo export > backup.json              # Export all data
+  bujo export --from 2026-01-01          # Export from date
+  bujo export --from 2026-01-01 --to 2026-01-31  # Export date range`,
+	RunE: runExport,
+}
+
+var (
+	exportFrom   string
+	exportTo     string
+	exportFormat string
+)
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringVar(&exportFrom, "from", "", "Start date for export (YYYY-MM-DD)")
+	exportCmd.Flags().StringVar(&exportTo, "to", "", "End date for export (YYYY-MM-DD)")
+	exportCmd.Flags().StringVar(&exportFormat, "format", "json", "Export format (json or csv)")
+}
+
+func runExport(cmd *cobra.Command, args []string) error {
+	entryRepo := sqlite.NewEntryRepository(db)
+	habitRepo := sqlite.NewHabitRepository(db)
+	habitLogRepo := sqlite.NewHabitLogRepository(db)
+	dayContextRepo := sqlite.NewDayContextRepository(db)
+	summaryRepo := sqlite.NewSummaryRepository(db)
+	listRepo := sqlite.NewListRepository(db)
+	listItemRepo := sqlite.NewListItemRepository(db)
+	goalRepo := sqlite.NewGoalRepository(db)
+
+	exportSvc := service.NewExportService(
+		entryRepo, habitRepo, habitLogRepo, dayContextRepo,
+		summaryRepo, listRepo, listItemRepo, goalRepo,
+	)
+
+	opts := domain.NewExportOptions()
+
+	if exportFrom != "" {
+		from, err := time.Parse("2006-01-02", exportFrom)
+		if err != nil {
+			return fmt.Errorf("invalid --from date: %w", err)
+		}
+		to := from
+		if exportTo != "" {
+			to, err = time.Parse("2006-01-02", exportTo)
+			if err != nil {
+				return fmt.Errorf("invalid --to date: %w", err)
+			}
+		}
+		opts = opts.WithDateRange(from, to)
+	}
+
+	data, err := exportSvc.Export(cmd.Context(), opts)
+	if err != nil {
+		return fmt.Errorf("export failed: %w", err)
+	}
+
+	if exportFormat == "csv" {
+		return exportCSV(data)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(data)
+}
+
+func exportCSV(data *domain.ExportData) error {
+	fmt.Fprintln(os.Stderr, "CSV export creates separate files for each entity type.")
+
+	if err := writeEntriesCSV(data.Entries); err != nil {
+		return err
+	}
+	if err := writeHabitsCSV(data.Habits); err != nil {
+		return err
+	}
+	if err := writeHabitLogsCSV(data.HabitLogs); err != nil {
+		return err
+	}
+	if err := writeListsCSV(data.Lists); err != nil {
+		return err
+	}
+	if err := writeListItemsCSV(data.ListItems); err != nil {
+		return err
+	}
+	if err := writeGoalsCSV(data.Goals); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stderr, "Export complete.")
+	return nil
+}
+
+func writeEntriesCSV(entries []domain.Entry) error {
+	f, err := os.Create("entries.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "id,entity_id,type,content,priority,parent_id,depth,location,scheduled_date,created_at"); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		scheduledDate := ""
+		if e.ScheduledDate != nil {
+			scheduledDate = e.ScheduledDate.Format("2006-01-02")
+		}
+		parentID := ""
+		if e.ParentID != nil {
+			parentID = fmt.Sprintf("%d", *e.ParentID)
+		}
+		location := ""
+		if e.Location != nil {
+			location = *e.Location
+		}
+		if _, err := fmt.Fprintf(f, "%d,%s,%s,%q,%s,%s,%d,%q,%s,%s\n",
+			e.ID, e.EntityID, e.Type, e.Content, e.Priority, parentID, e.Depth, location, scheduledDate, e.CreatedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created entries.csv")
+	return nil
+}
+
+func writeHabitsCSV(habits []domain.Habit) error {
+	f, err := os.Create("habits.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "id,entity_id,name,goal_per_day,goal_per_week,goal_per_month,created_at"); err != nil {
+		return err
+	}
+	for _, h := range habits {
+		if _, err := fmt.Fprintf(f, "%d,%s,%q,%d,%d,%d,%s\n",
+			h.ID, h.EntityID, h.Name, h.GoalPerDay, h.GoalPerWeek, h.GoalPerMonth, h.CreatedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created habits.csv")
+	return nil
+}
+
+func writeHabitLogsCSV(logs []domain.HabitLog) error {
+	f, err := os.Create("habit_logs.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "id,entity_id,habit_id,habit_entity_id,count,logged_at"); err != nil {
+		return err
+	}
+	for _, l := range logs {
+		if _, err := fmt.Fprintf(f, "%d,%s,%d,%s,%d,%s\n",
+			l.ID, l.EntityID, l.HabitID, l.HabitEntityID, l.Count, l.LoggedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created habit_logs.csv")
+	return nil
+}
+
+func writeListsCSV(lists []domain.List) error {
+	f, err := os.Create("lists.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "id,entity_id,name,created_at"); err != nil {
+		return err
+	}
+	for _, l := range lists {
+		if _, err := fmt.Fprintf(f, "%d,%s,%q,%s\n",
+			l.ID, l.EntityID, l.Name, l.CreatedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created lists.csv")
+	return nil
+}
+
+func writeListItemsCSV(items []domain.ListItem) error {
+	f, err := os.Create("list_items.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "row_id,entity_id,version,list_entity_id,type,content,created_at"); err != nil {
+		return err
+	}
+	for _, i := range items {
+		if _, err := fmt.Fprintf(f, "%d,%s,%d,%s,%s,%q,%s\n",
+			i.RowID, i.EntityID, i.Version, i.ListEntityID, i.Type, i.Content, i.CreatedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created list_items.csv")
+	return nil
+}
+
+func writeGoalsCSV(goals []domain.Goal) error {
+	f, err := os.Create("goals.csv")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, "id,entity_id,content,month,status,created_at"); err != nil {
+		return err
+	}
+	for _, g := range goals {
+		if _, err := fmt.Fprintf(f, "%d,%s,%q,%s,%s,%s\n",
+			g.ID, g.EntityID, g.Content, g.Month.Format("2006-01"), g.Status, g.CreatedAt.Format("2006-01-02T15:04:05Z07:00")); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "  Created goals.csv")
+	return nil
+}

--- a/cmd/bujo/cmd/import.go
+++ b/cmd/bujo/cmd/import.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/typingincolor/bujo/internal/domain"
+	"github.com/typingincolor/bujo/internal/repository/sqlite"
+	"github.com/typingincolor/bujo/internal/service"
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import <file>",
+	Short: "Import data from a JSON backup file",
+	Long: `Import bujo data from a JSON backup file.
+
+Modes:
+  merge   - Add new records, skip if entity_id already exists (default)
+  replace - Clear all existing data and import fresh (destructive)
+
+Examples:
+  bujo import backup.json                    # Merge with existing data
+  bujo import backup.json --mode replace     # Replace all data`,
+	Args: cobra.ExactArgs(1),
+	RunE: runImport,
+}
+
+var importMode string
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+	importCmd.Flags().StringVar(&importMode, "mode", "merge", "Import mode: merge or replace")
+}
+
+func runImport(cmd *cobra.Command, args []string) error {
+	filename := args[0]
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var data domain.ExportData
+	if err := json.NewDecoder(file).Decode(&data); err != nil {
+		return fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	if data.Version != domain.ExportVersion {
+		fmt.Fprintf(os.Stderr, "Warning: Export version %s differs from current version %s\n", data.Version, domain.ExportVersion)
+	}
+
+	mode := domain.ImportModeMerge
+	if importMode == "replace" {
+		mode = domain.ImportModeReplace
+		fmt.Fprintln(os.Stderr, "Warning: Replace mode will delete all existing data!")
+	}
+
+	entryRepo := sqlite.NewEntryRepository(db)
+	habitRepo := sqlite.NewHabitRepository(db)
+	habitLogRepo := sqlite.NewHabitLogRepository(db)
+	dayContextRepo := sqlite.NewDayContextRepository(db)
+	summaryRepo := sqlite.NewSummaryRepository(db)
+	listRepo := sqlite.NewListRepository(db)
+	listItemRepo := sqlite.NewListItemRepository(db)
+	goalRepo := sqlite.NewGoalRepository(db)
+
+	importSvc := service.NewImportService(
+		entryRepo, habitRepo, habitLogRepo, dayContextRepo,
+		summaryRepo, listRepo, listItemRepo, goalRepo,
+	)
+
+	opts := domain.NewImportOptions(mode)
+
+	if err := importSvc.Import(cmd.Context(), &data, opts); err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Import complete:\n")
+	fmt.Fprintf(os.Stderr, "  Entries:     %d\n", len(data.Entries))
+	fmt.Fprintf(os.Stderr, "  Habits:      %d\n", len(data.Habits))
+	fmt.Fprintf(os.Stderr, "  Habit Logs:  %d\n", len(data.HabitLogs))
+	fmt.Fprintf(os.Stderr, "  Day Contexts: %d\n", len(data.DayContexts))
+	fmt.Fprintf(os.Stderr, "  Summaries:   %d\n", len(data.Summaries))
+	fmt.Fprintf(os.Stderr, "  Lists:       %d\n", len(data.Lists))
+	fmt.Fprintf(os.Stderr, "  List Items:  %d\n", len(data.ListItems))
+	fmt.Fprintf(os.Stderr, "  Goals:       %d\n", len(data.Goals))
+
+	return nil
+}

--- a/internal/domain/export.go
+++ b/internal/domain/export.go
@@ -1,0 +1,48 @@
+package domain
+
+import "time"
+
+const ExportVersion = "1.0"
+
+type ExportData struct {
+	Version     string       `json:"version"`
+	ExportedAt  time.Time    `json:"exported_at"`
+	Entries     []Entry      `json:"entries"`
+	Habits      []Habit      `json:"habits"`
+	HabitLogs   []HabitLog   `json:"habit_logs"`
+	DayContexts []DayContext `json:"day_contexts"`
+	Summaries   []Summary    `json:"summaries"`
+	Lists       []List       `json:"lists"`
+	ListItems   []ListItem   `json:"list_items"`
+	Goals       []Goal       `json:"goals"`
+}
+
+type ExportOptions struct {
+	DateFrom *time.Time
+	DateTo   *time.Time
+}
+
+func NewExportOptions() ExportOptions {
+	return ExportOptions{}
+}
+
+func (o ExportOptions) WithDateRange(from, to time.Time) ExportOptions {
+	o.DateFrom = &from
+	o.DateTo = &to
+	return o
+}
+
+type ImportMode string
+
+const (
+	ImportModeMerge   ImportMode = "merge"
+	ImportModeReplace ImportMode = "replace"
+)
+
+type ImportOptions struct {
+	Mode ImportMode
+}
+
+func NewImportOptions(mode ImportMode) ImportOptions {
+	return ImportOptions{Mode: mode}
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -11,12 +11,14 @@ type EntryRepository interface {
 	GetByEntityID(ctx context.Context, entityID EntityID) (*Entry, error)
 	GetByDate(ctx context.Context, date time.Time) ([]Entry, error)
 	GetByDateRange(ctx context.Context, from, to time.Time) ([]Entry, error)
+	GetAll(ctx context.Context) ([]Entry, error)
 	GetOverdue(ctx context.Context, date time.Time) ([]Entry, error)
 	GetWithChildren(ctx context.Context, id int64) ([]Entry, error)
 	GetChildren(ctx context.Context, parentID int64) ([]Entry, error)
 	GetByListID(ctx context.Context, listID int64) ([]Entry, error)
 	Update(ctx context.Context, entry Entry) error
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 	DeleteWithChildren(ctx context.Context, id int64) error
 	GetHistory(ctx context.Context, entityID EntityID) ([]Entry, error)
 	GetAsOf(ctx context.Context, entityID EntityID, asOf time.Time) (*Entry, error)
@@ -26,11 +28,13 @@ type EntryRepository interface {
 type HabitRepository interface {
 	Insert(ctx context.Context, habit Habit) (int64, error)
 	GetByID(ctx context.Context, id int64) (*Habit, error)
+	GetByEntityID(ctx context.Context, entityID EntityID) (*Habit, error)
 	GetByName(ctx context.Context, name string) (*Habit, error)
 	GetOrCreate(ctx context.Context, name string, goalPerDay int) (*Habit, error)
 	GetAll(ctx context.Context) ([]Habit, error)
 	Update(ctx context.Context, habit Habit) error
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 }
 
 type HabitLogRepository interface {
@@ -38,30 +42,38 @@ type HabitLogRepository interface {
 	GetByHabitID(ctx context.Context, habitID int64) ([]HabitLog, error)
 	GetRange(ctx context.Context, habitID int64, start, end time.Time) ([]HabitLog, error)
 	GetAllRange(ctx context.Context, start, end time.Time) ([]HabitLog, error)
+	GetAll(ctx context.Context) ([]HabitLog, error)
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 }
 
 type DayContextRepository interface {
 	Upsert(ctx context.Context, dayCtx DayContext) error
 	GetByDate(ctx context.Context, date time.Time) (*DayContext, error)
 	GetRange(ctx context.Context, start, end time.Time) ([]DayContext, error)
+	GetAll(ctx context.Context) ([]DayContext, error)
+	DeleteAll(ctx context.Context) error
 }
 
 type SummaryRepository interface {
 	Insert(ctx context.Context, summary Summary) (int64, error)
 	Get(ctx context.Context, horizon SummaryHorizon, start, end time.Time) (*Summary, error)
 	GetByHorizon(ctx context.Context, horizon SummaryHorizon) ([]Summary, error)
+	GetAll(ctx context.Context) ([]Summary, error)
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 }
 
 type ListRepository interface {
 	Create(ctx context.Context, name string) (*List, error)
+	InsertWithEntityID(ctx context.Context, list List) (int64, error)
 	GetByID(ctx context.Context, id int64) (*List, error)
 	GetByName(ctx context.Context, name string) (*List, error)
 	GetByEntityID(ctx context.Context, entityID EntityID) (*List, error)
 	GetAll(ctx context.Context) ([]List, error)
 	Rename(ctx context.Context, id int64, newName string) error
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 	GetItemCount(ctx context.Context, listID int64) (int, error)
 	GetDoneCount(ctx context.Context, listID int64) (int, error)
 }
@@ -72,8 +84,10 @@ type ListItemRepository interface {
 	GetByEntityID(ctx context.Context, entityID EntityID) (*ListItem, error)
 	GetByListEntityID(ctx context.Context, listEntityID EntityID) ([]ListItem, error)
 	GetByListID(ctx context.Context, listID int64) ([]ListItem, error)
+	GetAll(ctx context.Context) ([]ListItem, error)
 	Update(ctx context.Context, item ListItem) error
 	Delete(ctx context.Context, id int64) error
+	DeleteAll(ctx context.Context) error
 	GetHistory(ctx context.Context, entityID EntityID) ([]ListItem, error)
 	GetAtVersion(ctx context.Context, entityID EntityID, version int) (*ListItem, error)
 	CountArchivable(ctx context.Context, olderThan time.Time) (int, error)

--- a/internal/repository/sqlite/goal_repository.go
+++ b/internal/repository/sqlite/goal_repository.go
@@ -225,6 +225,20 @@ func (r *GoalRepository) Delete(ctx context.Context, id int64) error {
 	return tx.Commit()
 }
 
+func (r *GoalRepository) DeleteAll(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM goals")
+	return err
+}
+
+func (r *GoalRepository) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Goal, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, entity_id, content, month, status, created_at
+		FROM goals WHERE entity_id = ? AND (valid_to IS NULL OR valid_to = '') AND op_type != 'DELETE'
+	`, entityID.String())
+
+	return r.scanGoal(row)
+}
+
 func (r *GoalRepository) MoveToMonth(ctx context.Context, id int64, newMonth time.Time) error {
 	goal, err := r.GetByID(ctx, id)
 	if err != nil {

--- a/internal/repository/sqlite/habit_log_repository.go
+++ b/internal/repository/sqlite/habit_log_repository.go
@@ -126,6 +126,26 @@ func (r *HabitLogRepository) GetAllRange(ctx context.Context, start, end time.Ti
 	return r.scanLogs(rows)
 }
 
+func (r *HabitLogRepository) GetAll(ctx context.Context) ([]domain.HabitLog, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, habit_id, count, logged_at, entity_id, habit_entity_id
+		FROM habit_logs
+		WHERE (valid_to IS NULL OR valid_to = '') AND op_type != 'DELETE'
+		ORDER BY logged_at
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	return r.scanLogs(rows)
+}
+
+func (r *HabitLogRepository) DeleteAll(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM habit_logs")
+	return err
+}
+
 func (r *HabitLogRepository) Delete(ctx context.Context, id int64) error {
 	log, err := r.GetByID(ctx, id)
 	if err != nil {

--- a/internal/repository/sqlite/habit_repository.go
+++ b/internal/repository/sqlite/habit_repository.go
@@ -219,6 +219,20 @@ func (r *HabitRepository) Delete(ctx context.Context, id int64) error {
 	return tx.Commit()
 }
 
+func (r *HabitRepository) DeleteAll(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM habits")
+	return err
+}
+
+func (r *HabitRepository) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Habit, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, name, goal_per_day, goal_per_week, goal_per_month, created_at, entity_id
+		FROM habits WHERE entity_id = ? AND (valid_to IS NULL OR valid_to = '') AND op_type != 'DELETE'
+	`, entityID.String())
+
+	return r.scanHabit(row)
+}
+
 func (r *HabitRepository) GetDeleted(ctx context.Context) ([]domain.Habit, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, goal_per_day, goal_per_week, goal_per_month, created_at, entity_id

--- a/internal/service/export.go
+++ b/internal/service/export.go
@@ -1,0 +1,352 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/typingincolor/bujo/internal/domain"
+)
+
+type ExportEntryRepository interface {
+	GetAll(ctx context.Context) ([]domain.Entry, error)
+	GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error)
+}
+
+type ExportHabitRepository interface {
+	GetAll(ctx context.Context) ([]domain.Habit, error)
+}
+
+type ExportHabitLogRepository interface {
+	GetAll(ctx context.Context) ([]domain.HabitLog, error)
+}
+
+type ExportDayContextRepository interface {
+	GetAll(ctx context.Context) ([]domain.DayContext, error)
+}
+
+type ExportSummaryRepository interface {
+	GetAll(ctx context.Context) ([]domain.Summary, error)
+}
+
+type ExportListRepository interface {
+	GetAll(ctx context.Context) ([]domain.List, error)
+}
+
+type ExportListItemRepository interface {
+	GetAll(ctx context.Context) ([]domain.ListItem, error)
+}
+
+type ExportGoalRepository interface {
+	GetAll(ctx context.Context) ([]domain.Goal, error)
+}
+
+type ExportService struct {
+	entryRepo      ExportEntryRepository
+	habitRepo      ExportHabitRepository
+	habitLogRepo   ExportHabitLogRepository
+	dayContextRepo ExportDayContextRepository
+	summaryRepo    ExportSummaryRepository
+	listRepo       ExportListRepository
+	listItemRepo   ExportListItemRepository
+	goalRepo       ExportGoalRepository
+}
+
+func NewExportService(
+	entryRepo ExportEntryRepository,
+	habitRepo ExportHabitRepository,
+	habitLogRepo ExportHabitLogRepository,
+	dayContextRepo ExportDayContextRepository,
+	summaryRepo ExportSummaryRepository,
+	listRepo ExportListRepository,
+	listItemRepo ExportListItemRepository,
+	goalRepo ExportGoalRepository,
+) *ExportService {
+	return &ExportService{
+		entryRepo:      entryRepo,
+		habitRepo:      habitRepo,
+		habitLogRepo:   habitLogRepo,
+		dayContextRepo: dayContextRepo,
+		summaryRepo:    summaryRepo,
+		listRepo:       listRepo,
+		listItemRepo:   listItemRepo,
+		goalRepo:       goalRepo,
+	}
+}
+
+type ImportEntryRepository interface {
+	Insert(ctx context.Context, entry domain.Entry) (int64, error)
+	GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Entry, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportHabitRepository interface {
+	Insert(ctx context.Context, habit domain.Habit) (int64, error)
+	GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Habit, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportHabitLogRepository interface {
+	Insert(ctx context.Context, log domain.HabitLog) (int64, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportDayContextRepository interface {
+	Upsert(ctx context.Context, dc domain.DayContext) error
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportSummaryRepository interface {
+	Insert(ctx context.Context, s domain.Summary) (int64, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportListRepository interface {
+	InsertWithEntityID(ctx context.Context, list domain.List) (int64, error)
+	GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.List, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportListItemRepository interface {
+	Insert(ctx context.Context, item domain.ListItem) (int64, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportGoalRepository interface {
+	Insert(ctx context.Context, goal domain.Goal) (int64, error)
+	GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Goal, error)
+	DeleteAll(ctx context.Context) error
+}
+
+type ImportService struct {
+	entryRepo      ImportEntryRepository
+	habitRepo      ImportHabitRepository
+	habitLogRepo   ImportHabitLogRepository
+	dayContextRepo ImportDayContextRepository
+	summaryRepo    ImportSummaryRepository
+	listRepo       ImportListRepository
+	listItemRepo   ImportListItemRepository
+	goalRepo       ImportGoalRepository
+}
+
+func NewImportService(
+	entryRepo ImportEntryRepository,
+	habitRepo ImportHabitRepository,
+	habitLogRepo ImportHabitLogRepository,
+	dayContextRepo ImportDayContextRepository,
+	summaryRepo ImportSummaryRepository,
+	listRepo ImportListRepository,
+	listItemRepo ImportListItemRepository,
+	goalRepo ImportGoalRepository,
+) *ImportService {
+	return &ImportService{
+		entryRepo:      entryRepo,
+		habitRepo:      habitRepo,
+		habitLogRepo:   habitLogRepo,
+		dayContextRepo: dayContextRepo,
+		summaryRepo:    summaryRepo,
+		listRepo:       listRepo,
+		listItemRepo:   listItemRepo,
+		goalRepo:       goalRepo,
+	}
+}
+
+func (s *ImportService) Import(ctx context.Context, data *domain.ExportData, opts domain.ImportOptions) error {
+	if opts.Mode == domain.ImportModeReplace {
+		if err := s.clearAllData(ctx); err != nil {
+			return err
+		}
+	}
+
+	for _, entry := range data.Entries {
+		if opts.Mode == domain.ImportModeMerge {
+			existing, err := s.entryRepo.GetByEntityID(ctx, entry.EntityID)
+			if err != nil {
+				return err
+			}
+			if existing != nil {
+				continue
+			}
+		}
+		if _, err := s.entryRepo.Insert(ctx, entry); err != nil {
+			return err
+		}
+	}
+
+	for _, habit := range data.Habits {
+		if opts.Mode == domain.ImportModeMerge {
+			existing, err := s.habitRepo.GetByEntityID(ctx, habit.EntityID)
+			if err != nil {
+				return err
+			}
+			if existing != nil {
+				continue
+			}
+		}
+		if _, err := s.habitRepo.Insert(ctx, habit); err != nil {
+			return err
+		}
+	}
+
+	for _, log := range data.HabitLogs {
+		if _, err := s.habitLogRepo.Insert(ctx, log); err != nil {
+			return err
+		}
+	}
+
+	for _, dc := range data.DayContexts {
+		if err := s.dayContextRepo.Upsert(ctx, dc); err != nil {
+			return err
+		}
+	}
+
+	for _, summary := range data.Summaries {
+		if _, err := s.summaryRepo.Insert(ctx, summary); err != nil {
+			return err
+		}
+	}
+
+	for _, list := range data.Lists {
+		if opts.Mode == domain.ImportModeMerge {
+			existing, err := s.listRepo.GetByEntityID(ctx, list.EntityID)
+			if err != nil {
+				return err
+			}
+			if existing != nil {
+				continue
+			}
+		}
+		if _, err := s.listRepo.InsertWithEntityID(ctx, list); err != nil {
+			return err
+		}
+	}
+
+	for _, item := range data.ListItems {
+		if _, err := s.listItemRepo.Insert(ctx, item); err != nil {
+			return err
+		}
+	}
+
+	for _, goal := range data.Goals {
+		if opts.Mode == domain.ImportModeMerge {
+			existing, err := s.goalRepo.GetByEntityID(ctx, goal.EntityID)
+			if err != nil {
+				return err
+			}
+			if existing != nil {
+				continue
+			}
+		}
+		if _, err := s.goalRepo.Insert(ctx, goal); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *ImportService) clearAllData(ctx context.Context) error {
+	if err := s.listItemRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.listRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.goalRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.summaryRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.dayContextRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.habitLogRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.habitRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	if err := s.entryRepo.DeleteAll(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ExportService) Export(ctx context.Context, opts domain.ExportOptions) (*domain.ExportData, error) {
+	data := &domain.ExportData{
+		Version:    domain.ExportVersion,
+		ExportedAt: time.Now(),
+	}
+
+	var err error
+
+	if opts.DateFrom != nil && opts.DateTo != nil {
+		data.Entries, err = s.entryRepo.GetByDateRange(ctx, *opts.DateFrom, *opts.DateTo)
+	} else {
+		data.Entries, err = s.entryRepo.GetAll(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if data.Entries == nil {
+		data.Entries = []domain.Entry{}
+	}
+
+	data.Habits, err = s.habitRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.Habits == nil {
+		data.Habits = []domain.Habit{}
+	}
+
+	data.HabitLogs, err = s.habitLogRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.HabitLogs == nil {
+		data.HabitLogs = []domain.HabitLog{}
+	}
+
+	data.DayContexts, err = s.dayContextRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.DayContexts == nil {
+		data.DayContexts = []domain.DayContext{}
+	}
+
+	data.Summaries, err = s.summaryRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.Summaries == nil {
+		data.Summaries = []domain.Summary{}
+	}
+
+	data.Lists, err = s.listRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.Lists == nil {
+		data.Lists = []domain.List{}
+	}
+
+	data.ListItems, err = s.listItemRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.ListItems == nil {
+		data.ListItems = []domain.ListItem{}
+	}
+
+	data.Goals, err = s.goalRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if data.Goals == nil {
+		data.Goals = []domain.Goal{}
+	}
+
+	return data, nil
+}

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -1,0 +1,482 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/typingincolor/bujo/internal/domain"
+)
+
+type mockEntryRepoForExport struct {
+	entries []domain.Entry
+}
+
+func (m *mockEntryRepoForExport) GetAll(ctx context.Context) ([]domain.Entry, error) {
+	return m.entries, nil
+}
+
+func (m *mockEntryRepoForExport) GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error) {
+	var result []domain.Entry
+	for _, e := range m.entries {
+		if e.ScheduledDate != nil && !e.ScheduledDate.Before(from) && !e.ScheduledDate.After(to) {
+			result = append(result, e)
+		}
+	}
+	return result, nil
+}
+
+type mockHabitRepoForExport struct {
+	habits []domain.Habit
+}
+
+func (m *mockHabitRepoForExport) GetAll(ctx context.Context) ([]domain.Habit, error) {
+	return m.habits, nil
+}
+
+type mockHabitLogRepoForExport struct {
+	logs []domain.HabitLog
+}
+
+func (m *mockHabitLogRepoForExport) GetAll(ctx context.Context) ([]domain.HabitLog, error) {
+	return m.logs, nil
+}
+
+type mockDayContextRepoForExport struct {
+	contexts []domain.DayContext
+}
+
+func (m *mockDayContextRepoForExport) GetAll(ctx context.Context) ([]domain.DayContext, error) {
+	return m.contexts, nil
+}
+
+type mockSummaryRepoForExport struct {
+	summaries []domain.Summary
+}
+
+func (m *mockSummaryRepoForExport) GetAll(ctx context.Context) ([]domain.Summary, error) {
+	return m.summaries, nil
+}
+
+type mockListRepoForExport struct {
+	lists []domain.List
+}
+
+func (m *mockListRepoForExport) GetAll(ctx context.Context) ([]domain.List, error) {
+	return m.lists, nil
+}
+
+type mockListItemRepoForExport struct {
+	items []domain.ListItem
+}
+
+func (m *mockListItemRepoForExport) GetAll(ctx context.Context) ([]domain.ListItem, error) {
+	return m.items, nil
+}
+
+type mockGoalRepoForExport struct {
+	goals []domain.Goal
+}
+
+func (m *mockGoalRepoForExport) GetAll(ctx context.Context) ([]domain.Goal, error) {
+	return m.goals, nil
+}
+
+func TestExportService_Export_AllData(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	date := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+
+	entryRepo := &mockEntryRepoForExport{
+		entries: []domain.Entry{
+			{ID: 1, Content: "Task 1", Type: domain.EntryTypeTask, ScheduledDate: &date},
+			{ID: 2, Content: "Note 1", Type: domain.EntryTypeNote, ScheduledDate: &date},
+		},
+	}
+	habitRepo := &mockHabitRepoForExport{
+		habits: []domain.Habit{
+			{ID: 1, Name: "Exercise", GoalPerDay: 1},
+		},
+	}
+	habitLogRepo := &mockHabitLogRepoForExport{
+		logs: []domain.HabitLog{
+			{ID: 1, HabitID: 1, Count: 1, LoggedAt: now},
+		},
+	}
+	dayContextRepo := &mockDayContextRepoForExport{
+		contexts: []domain.DayContext{
+			{Date: date, EntityID: domain.NewEntityID()},
+		},
+	}
+	summaryRepo := &mockSummaryRepoForExport{
+		summaries: []domain.Summary{
+			{ID: 1, Horizon: domain.SummaryHorizonDaily, Content: "Test summary"},
+		},
+	}
+	listRepo := &mockListRepoForExport{
+		lists: []domain.List{
+			{ID: 1, Name: "Groceries"},
+		},
+	}
+	listItemRepo := &mockListItemRepoForExport{
+		items: []domain.ListItem{
+			{VersionInfo: domain.VersionInfo{RowID: 1}, Content: "Milk", Type: domain.ListItemTypeTask},
+		},
+	}
+	goalRepo := &mockGoalRepoForExport{
+		goals: []domain.Goal{
+			{ID: 1, Content: "Learn Go", Status: domain.GoalStatusActive},
+		},
+	}
+
+	svc := NewExportService(entryRepo, habitRepo, habitLogRepo, dayContextRepo, summaryRepo, listRepo, listItemRepo, goalRepo)
+
+	data, err := svc.Export(ctx, domain.NewExportOptions())
+	if err != nil {
+		t.Fatalf("Export failed: %v", err)
+	}
+
+	if data.Version != domain.ExportVersion {
+		t.Errorf("Expected version %s, got %s", domain.ExportVersion, data.Version)
+	}
+
+	if len(data.Entries) != 2 {
+		t.Errorf("Expected 2 entries, got %d", len(data.Entries))
+	}
+
+	if len(data.Habits) != 1 {
+		t.Errorf("Expected 1 habit, got %d", len(data.Habits))
+	}
+
+	if len(data.HabitLogs) != 1 {
+		t.Errorf("Expected 1 habit log, got %d", len(data.HabitLogs))
+	}
+
+	if len(data.DayContexts) != 1 {
+		t.Errorf("Expected 1 day context, got %d", len(data.DayContexts))
+	}
+
+	if len(data.Summaries) != 1 {
+		t.Errorf("Expected 1 summary, got %d", len(data.Summaries))
+	}
+
+	if len(data.Lists) != 1 {
+		t.Errorf("Expected 1 list, got %d", len(data.Lists))
+	}
+
+	if len(data.ListItems) != 1 {
+		t.Errorf("Expected 1 list item, got %d", len(data.ListItems))
+	}
+
+	if len(data.Goals) != 1 {
+		t.Errorf("Expected 1 goal, got %d", len(data.Goals))
+	}
+}
+
+func TestExportService_Export_WithDateRange(t *testing.T) {
+	ctx := context.Background()
+	jan5 := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	jan10 := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	jan15 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	entryRepo := &mockEntryRepoForExport{
+		entries: []domain.Entry{
+			{ID: 1, Content: "Entry on Jan 5", Type: domain.EntryTypeTask, ScheduledDate: &jan5},
+			{ID: 2, Content: "Entry on Jan 10", Type: domain.EntryTypeTask, ScheduledDate: &jan10},
+			{ID: 3, Content: "Entry on Jan 15", Type: domain.EntryTypeTask, ScheduledDate: &jan15},
+		},
+	}
+
+	svc := NewExportService(entryRepo, &mockHabitRepoForExport{}, &mockHabitLogRepoForExport{},
+		&mockDayContextRepoForExport{}, &mockSummaryRepoForExport{}, &mockListRepoForExport{},
+		&mockListItemRepoForExport{}, &mockGoalRepoForExport{})
+
+	from := time.Date(2026, 1, 8, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 12, 0, 0, 0, 0, time.UTC)
+	opts := domain.NewExportOptions().WithDateRange(from, to)
+
+	data, err := svc.Export(ctx, opts)
+	if err != nil {
+		t.Fatalf("Export failed: %v", err)
+	}
+
+	if len(data.Entries) != 1 {
+		t.Errorf("Expected 1 entry in date range, got %d", len(data.Entries))
+	}
+
+	if len(data.Entries) > 0 && data.Entries[0].Content != "Entry on Jan 10" {
+		t.Errorf("Expected 'Entry on Jan 10', got '%s'", data.Entries[0].Content)
+	}
+}
+
+func TestExportService_Export_EmptyData(t *testing.T) {
+	ctx := context.Background()
+
+	svc := NewExportService(&mockEntryRepoForExport{}, &mockHabitRepoForExport{}, &mockHabitLogRepoForExport{},
+		&mockDayContextRepoForExport{}, &mockSummaryRepoForExport{}, &mockListRepoForExport{},
+		&mockListItemRepoForExport{}, &mockGoalRepoForExport{})
+
+	data, err := svc.Export(ctx, domain.NewExportOptions())
+	if err != nil {
+		t.Fatalf("Export failed: %v", err)
+	}
+
+	if data.Version != domain.ExportVersion {
+		t.Errorf("Expected version %s, got %s", domain.ExportVersion, data.Version)
+	}
+
+	if data.Entries == nil {
+		t.Error("Entries should be empty slice, not nil")
+	}
+}
+
+type mockImportEntryRepo struct {
+	existing map[domain.EntityID]bool
+	inserted []domain.Entry
+	cleared  bool
+}
+
+func (m *mockImportEntryRepo) Insert(ctx context.Context, entry domain.Entry) (int64, error) {
+	m.inserted = append(m.inserted, entry)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportEntryRepo) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Entry, error) {
+	if m.existing[entityID] {
+		return &domain.Entry{EntityID: entityID}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockImportEntryRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	m.existing = make(map[domain.EntityID]bool)
+	return nil
+}
+
+type mockImportHabitRepo struct {
+	existing map[domain.EntityID]bool
+	inserted []domain.Habit
+	cleared  bool
+}
+
+func (m *mockImportHabitRepo) Insert(ctx context.Context, habit domain.Habit) (int64, error) {
+	m.inserted = append(m.inserted, habit)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportHabitRepo) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Habit, error) {
+	if m.existing[entityID] {
+		return &domain.Habit{EntityID: entityID}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockImportHabitRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	m.existing = make(map[domain.EntityID]bool)
+	return nil
+}
+
+type mockImportHabitLogRepo struct {
+	inserted []domain.HabitLog
+	cleared  bool
+}
+
+func (m *mockImportHabitLogRepo) Insert(ctx context.Context, log domain.HabitLog) (int64, error) {
+	m.inserted = append(m.inserted, log)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportHabitLogRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	return nil
+}
+
+type mockImportDayContextRepo struct {
+	inserted []domain.DayContext
+	cleared  bool
+}
+
+func (m *mockImportDayContextRepo) Upsert(ctx context.Context, dc domain.DayContext) error {
+	m.inserted = append(m.inserted, dc)
+	return nil
+}
+
+func (m *mockImportDayContextRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	return nil
+}
+
+type mockImportSummaryRepo struct {
+	inserted []domain.Summary
+	cleared  bool
+}
+
+func (m *mockImportSummaryRepo) Insert(ctx context.Context, s domain.Summary) (int64, error) {
+	m.inserted = append(m.inserted, s)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportSummaryRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	return nil
+}
+
+type mockImportListRepo struct {
+	existing map[domain.EntityID]bool
+	inserted []domain.List
+	cleared  bool
+}
+
+func (m *mockImportListRepo) Create(ctx context.Context, name string) (*domain.List, error) {
+	return nil, nil
+}
+
+func (m *mockImportListRepo) InsertWithEntityID(ctx context.Context, list domain.List) (int64, error) {
+	m.inserted = append(m.inserted, list)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportListRepo) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.List, error) {
+	if m.existing[entityID] {
+		return &domain.List{EntityID: entityID}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockImportListRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	m.existing = make(map[domain.EntityID]bool)
+	return nil
+}
+
+type mockImportListItemRepo struct {
+	inserted []domain.ListItem
+	cleared  bool
+}
+
+func (m *mockImportListItemRepo) Insert(ctx context.Context, item domain.ListItem) (int64, error) {
+	m.inserted = append(m.inserted, item)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportListItemRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	return nil
+}
+
+type mockImportGoalRepo struct {
+	existing map[domain.EntityID]bool
+	inserted []domain.Goal
+	cleared  bool
+}
+
+func (m *mockImportGoalRepo) Insert(ctx context.Context, goal domain.Goal) (int64, error) {
+	m.inserted = append(m.inserted, goal)
+	return int64(len(m.inserted)), nil
+}
+
+func (m *mockImportGoalRepo) GetByEntityID(ctx context.Context, entityID domain.EntityID) (*domain.Goal, error) {
+	if m.existing[entityID] {
+		return &domain.Goal{EntityID: entityID}, nil
+	}
+	return nil, nil
+}
+
+func (m *mockImportGoalRepo) DeleteAll(ctx context.Context) error {
+	m.cleared = true
+	m.existing = make(map[domain.EntityID]bool)
+	return nil
+}
+
+func TestImportService_Import_MergeMode(t *testing.T) {
+	ctx := context.Background()
+
+	existingEntityID := domain.NewEntityID()
+	newEntityID := domain.NewEntityID()
+
+	entryRepo := &mockImportEntryRepo{
+		existing: map[domain.EntityID]bool{existingEntityID: true},
+	}
+	habitRepo := &mockImportHabitRepo{existing: make(map[domain.EntityID]bool)}
+	habitLogRepo := &mockImportHabitLogRepo{}
+	dayContextRepo := &mockImportDayContextRepo{}
+	summaryRepo := &mockImportSummaryRepo{}
+	listRepo := &mockImportListRepo{existing: make(map[domain.EntityID]bool)}
+	listItemRepo := &mockImportListItemRepo{}
+	goalRepo := &mockImportGoalRepo{existing: make(map[domain.EntityID]bool)}
+
+	svc := NewImportService(entryRepo, habitRepo, habitLogRepo, dayContextRepo, summaryRepo, listRepo, listItemRepo, goalRepo)
+
+	data := &domain.ExportData{
+		Version: domain.ExportVersion,
+		Entries: []domain.Entry{
+			{EntityID: existingEntityID, Content: "Existing entry"},
+			{EntityID: newEntityID, Content: "New entry"},
+		},
+	}
+
+	opts := domain.NewImportOptions(domain.ImportModeMerge)
+	err := svc.Import(ctx, data, opts)
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if len(entryRepo.inserted) != 1 {
+		t.Errorf("Expected 1 inserted entry (skip existing), got %d", len(entryRepo.inserted))
+	}
+
+	if len(entryRepo.inserted) > 0 && entryRepo.inserted[0].Content != "New entry" {
+		t.Errorf("Expected 'New entry', got '%s'", entryRepo.inserted[0].Content)
+	}
+}
+
+func TestImportService_Import_ReplaceMode(t *testing.T) {
+	ctx := context.Background()
+
+	entryRepo := &mockImportEntryRepo{
+		existing: map[domain.EntityID]bool{domain.NewEntityID(): true},
+	}
+	habitRepo := &mockImportHabitRepo{existing: make(map[domain.EntityID]bool)}
+	habitLogRepo := &mockImportHabitLogRepo{}
+	dayContextRepo := &mockImportDayContextRepo{}
+	summaryRepo := &mockImportSummaryRepo{}
+	listRepo := &mockImportListRepo{existing: make(map[domain.EntityID]bool)}
+	listItemRepo := &mockImportListItemRepo{}
+	goalRepo := &mockImportGoalRepo{existing: make(map[domain.EntityID]bool)}
+
+	svc := NewImportService(entryRepo, habitRepo, habitLogRepo, dayContextRepo, summaryRepo, listRepo, listItemRepo, goalRepo)
+
+	data := &domain.ExportData{
+		Version: domain.ExportVersion,
+		Entries: []domain.Entry{
+			{EntityID: domain.NewEntityID(), Content: "Imported entry"},
+		},
+		Habits: []domain.Habit{
+			{EntityID: domain.NewEntityID(), Name: "Imported habit"},
+		},
+	}
+
+	opts := domain.NewImportOptions(domain.ImportModeReplace)
+	err := svc.Import(ctx, data, opts)
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if !entryRepo.cleared {
+		t.Error("Expected entries to be cleared in replace mode")
+	}
+
+	if !habitRepo.cleared {
+		t.Error("Expected habits to be cleared in replace mode")
+	}
+
+	if len(entryRepo.inserted) != 1 {
+		t.Errorf("Expected 1 inserted entry, got %d", len(entryRepo.inserted))
+	}
+
+	if len(habitRepo.inserted) != 1 {
+		t.Errorf("Expected 1 inserted habit, got %d", len(habitRepo.inserted))
+	}
+}


### PR DESCRIPTION
## Summary
- Add JSON export with optional date range filtering and CSV export (separate files per entity type)
- Add import command with merge mode (skip existing) and replace mode (clear all data first)
- Export/import supports all entities: entries, habits, habit_logs, day_contexts, summaries, lists, list_items, goals

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)