### PR TITLE
feat(stats): add stats command for summary statistics (#21)

### DIFF
--- a/cmd/bujo/cmd/root.go
+++ b/cmd/bujo/cmd/root.go
@@ -29,6 +29,7 @@ var (
 	listService    *service.ListService
 	goalService    *service.GoalService
 	summaryService *service.SummaryService
+	statsService   *service.StatsService
 )
 
 var rootCmd = &cobra.Command{
@@ -73,6 +74,7 @@ var rootCmd = &cobra.Command{
 		habitService = service.NewHabitService(habitRepo, habitLogRepo)
 		listService = service.NewListService(listRepo, listItemRepo)
 		goalService = service.NewGoalService(goalRepo)
+		statsService = service.NewStatsService(entryRepo, habitRepo, habitLogRepo)
 
 		// Initialize summary service if API key is available
 		summaryRepo := sqlite.NewSummaryRepository(db)

--- a/cmd/bujo/cmd/stats.go
+++ b/cmd/bujo/cmd/stats.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/typingincolor/bujo/internal/adapter/cli"
+)
+
+var (
+	statsFrom string
+	statsTo   string
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show summary statistics",
+	Long: `Show summary statistics about your journal usage.
+
+Displays entry counts by type, task completion rate, productivity patterns,
+and habit tracking overview.
+
+Examples:
+  bujo stats                       # Stats for the last 30 days
+  bujo stats --from "last month"   # Custom date range
+  bujo stats --from "2026-01-01" --to "2026-01-31"  # Specific range`,
+	RunE: runStats,
+}
+
+func init() {
+	statsCmd.Flags().StringVarP(&statsFrom, "from", "f", "", "Start date (natural language or YYYY-MM-DD)")
+	statsCmd.Flags().StringVarP(&statsTo, "to", "t", "", "End date (natural language or YYYY-MM-DD)")
+	rootCmd.AddCommand(statsCmd)
+}
+
+func runStats(cmd *cobra.Command, args []string) error {
+	to := time.Now()
+	from := to.AddDate(0, 0, -29) // Default: last 30 days
+
+	if statsFrom != "" {
+		parsed, err := parsePastDate(statsFrom)
+		if err != nil {
+			return fmt.Errorf("invalid --from date: %w", err)
+		}
+		from = parsed
+	}
+
+	if statsTo != "" {
+		parsed, err := parsePastDate(statsTo)
+		if err != nil {
+			return fmt.Errorf("invalid --to date: %w", err)
+		}
+		to = parsed
+	}
+
+	stats, err := statsService.GetStats(cmd.Context(), from, to)
+	if err != nil {
+		return fmt.Errorf("failed to get stats: %w", err)
+	}
+
+	days := int(to.Sub(from).Hours()/24) + 1
+	fmt.Printf("%s Statistics (%s to %s)\n", cli.Bold("📊"), from.Format("Jan 2"), to.Format("Jan 2, 2006"))
+	fmt.Println(cli.Dimmed("───────────────────────────────"))
+
+	// Entry counts
+	fmt.Printf("\n%s %d total\n", cli.Bold("Entries:"), stats.EntryCounts.Total)
+	if stats.EntryCounts.Tasks > 0 {
+		pct := float64(stats.EntryCounts.Tasks) / float64(stats.EntryCounts.Total) * 100
+		fmt.Printf("  • Tasks:     %d (%.0f%%)\n", stats.EntryCounts.Tasks, pct)
+	}
+	if stats.EntryCounts.Notes > 0 {
+		pct := float64(stats.EntryCounts.Notes) / float64(stats.EntryCounts.Total) * 100
+		fmt.Printf("  – Notes:     %d (%.0f%%)\n", stats.EntryCounts.Notes, pct)
+	}
+	if stats.EntryCounts.Events > 0 {
+		pct := float64(stats.EntryCounts.Events) / float64(stats.EntryCounts.Total) * 100
+		fmt.Printf("  ○ Events:    %d (%.0f%%)\n", stats.EntryCounts.Events, pct)
+	}
+	if stats.EntryCounts.Done > 0 {
+		pct := float64(stats.EntryCounts.Done) / float64(stats.EntryCounts.Total) * 100
+		fmt.Printf("  ✓ Completed: %d (%.0f%%)\n", stats.EntryCounts.Done, pct)
+	}
+	if stats.EntryCounts.Migrated > 0 {
+		pct := float64(stats.EntryCounts.Migrated) / float64(stats.EntryCounts.Total) * 100
+		fmt.Printf("  → Migrated:  %d (%.0f%%)\n", stats.EntryCounts.Migrated, pct)
+	}
+
+	// Task completion
+	if stats.TaskCompletion.Total > 0 {
+		fmt.Printf("\n%s %.0f%% (%d/%d)\n",
+			cli.Bold("Task completion:"),
+			stats.TaskCompletion.Rate,
+			stats.TaskCompletion.Completed,
+			stats.TaskCompletion.Total,
+		)
+	}
+
+	// Productivity
+	if stats.Productivity.AveragePerDay > 0 {
+		fmt.Printf("%s %.1f\n", cli.Bold("Average entries/day:"), stats.Productivity.AveragePerDay)
+	}
+
+	if stats.Productivity.MostProductive.Average > 0 {
+		fmt.Printf("\n%s %s (avg %.1f)\n",
+			cli.Bold("Most productive:"),
+			stats.Productivity.MostProductive.Day.String()+"s",
+			stats.Productivity.MostProductive.Average,
+		)
+	}
+	if stats.Productivity.LeastProductive.Average > 0 && days > 7 {
+		fmt.Printf("%s %s (avg %.1f)\n",
+			cli.Bold("Least productive:"),
+			stats.Productivity.LeastProductive.Day.String()+"s",
+			stats.Productivity.LeastProductive.Average,
+		)
+	}
+
+	// Habits
+	if stats.HabitStats.Active > 0 {
+		fmt.Printf("\n%s %d active\n", cli.Bold("Habits:"), stats.HabitStats.Active)
+		if stats.HabitStats.BestStreak.Days > 0 {
+			fmt.Printf("  Best streak: %s (%d days)\n",
+				stats.HabitStats.BestStreak.HabitName,
+				stats.HabitStats.BestStreak.Days,
+			)
+		}
+		if stats.HabitStats.MostLogged.Count > 0 {
+			fmt.Printf("  Most logged: %s (%d logs)\n",
+				stats.HabitStats.MostLogged.HabitName,
+				stats.HabitStats.MostLogged.Count,
+			)
+		}
+	}
+
+	return nil
+}

--- a/cmd/bujo/cmd/tui.go
+++ b/cmd/bujo/cmd/tui.go
@@ -19,6 +19,7 @@ var tuiCmd = &cobra.Command{
 			ListService:    listService,
 			GoalService:    goalService,
 			SummaryService: summaryService,
+			StatsService:   statsService,
 		})
 		p := tea.NewProgram(model, tea.WithAltScreen())
 

--- a/internal/domain/stats.go
+++ b/internal/domain/stats.go
@@ -1,0 +1,62 @@
+package domain
+
+import "time"
+
+type Stats struct {
+	Period         StatsPeriod
+	TotalDays      int
+	EntryCounts    EntryCounts
+	TaskCompletion TaskCompletion
+	Productivity   Productivity
+	HabitStats     HabitStats
+}
+
+type StatsPeriod struct {
+	From time.Time
+	To   time.Time
+}
+
+type EntryCounts struct {
+	Total     int
+	Tasks     int
+	Notes     int
+	Events    int
+	Done      int
+	Migrated  int
+	Cancelled int
+}
+
+type TaskCompletion struct {
+	Total     int
+	Completed int
+	Rate      float64
+}
+
+type Productivity struct {
+	AveragePerDay  float64
+	MostProductive Weekday
+	LeastProductive Weekday
+	EntriesByDay   map[time.Weekday]int
+}
+
+type Weekday struct {
+	Day     time.Weekday
+	Average float64
+}
+
+type HabitStats struct {
+	Active      int
+	BestStreak  HabitStreak
+	MostLogged  HabitLogCount
+	TotalLogs   int
+}
+
+type HabitStreak struct {
+	HabitName string
+	Days      int
+}
+
+type HabitLogCount struct {
+	HabitName string
+	Count     int
+}

--- a/internal/service/stats.go
+++ b/internal/service/stats.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/typingincolor/bujo/internal/domain"
+)
+
+type StatsEntryRepository interface {
+	GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error)
+}
+
+type StatsHabitRepository interface {
+	GetAll(ctx context.Context) ([]domain.Habit, error)
+}
+
+type StatsHabitLogRepository interface {
+	GetAllRange(ctx context.Context, start, end time.Time) ([]domain.HabitLog, error)
+	GetByHabitID(ctx context.Context, habitID int64) ([]domain.HabitLog, error)
+}
+
+type StatsService struct {
+	entryRepo    StatsEntryRepository
+	habitRepo    StatsHabitRepository
+	habitLogRepo StatsHabitLogRepository
+}
+
+func NewStatsService(
+	entryRepo StatsEntryRepository,
+	habitRepo StatsHabitRepository,
+	habitLogRepo StatsHabitLogRepository,
+) *StatsService {
+	return &StatsService{
+		entryRepo:    entryRepo,
+		habitRepo:    habitRepo,
+		habitLogRepo: habitLogRepo,
+	}
+}
+
+func (s *StatsService) GetStats(ctx context.Context, from, to time.Time) (*domain.Stats, error) {
+	entries, err := s.entryRepo.GetByDateRange(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	habits, err := s.habitRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	logs, err := s.habitLogRepo.GetAllRange(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &domain.Stats{
+		Period: domain.StatsPeriod{
+			From: from,
+			To:   to,
+		},
+		TotalDays: int(to.Sub(from).Hours()/24) + 1,
+	}
+
+	stats.EntryCounts = s.countEntries(entries)
+	stats.TaskCompletion = s.calculateTaskCompletion(entries)
+	stats.Productivity = s.calculateProductivity(entries)
+	stats.HabitStats = s.calculateHabitStats(ctx, habits, logs, to)
+
+	return stats, nil
+}
+
+func (s *StatsService) countEntries(entries []domain.Entry) domain.EntryCounts {
+	counts := domain.EntryCounts{
+		Total: len(entries),
+	}
+
+	for _, e := range entries {
+		switch e.Type {
+		case domain.EntryTypeTask:
+			counts.Tasks++
+		case domain.EntryTypeNote:
+			counts.Notes++
+		case domain.EntryTypeEvent:
+			counts.Events++
+		case domain.EntryTypeDone:
+			counts.Done++
+		case domain.EntryTypeMigrated:
+			counts.Migrated++
+		case domain.EntryTypeCancelled:
+			counts.Cancelled++
+		}
+	}
+
+	return counts
+}
+
+func (s *StatsService) calculateTaskCompletion(entries []domain.Entry) domain.TaskCompletion {
+	var total, completed int
+
+	for _, e := range entries {
+		switch e.Type {
+		case domain.EntryTypeTask:
+			total++
+		case domain.EntryTypeDone, domain.EntryTypeMigrated:
+			total++
+			completed++
+		}
+	}
+
+	rate := 0.0
+	if total > 0 {
+		rate = float64(completed) / float64(total) * 100
+	}
+
+	return domain.TaskCompletion{
+		Total:     total,
+		Completed: completed,
+		Rate:      rate,
+	}
+}
+
+func (s *StatsService) calculateProductivity(entries []domain.Entry) domain.Productivity {
+	prod := domain.Productivity{
+		EntriesByDay: make(map[time.Weekday]int),
+	}
+
+	dayCount := make(map[time.Weekday]int)
+
+	for _, e := range entries {
+		if e.ScheduledDate == nil {
+			continue
+		}
+		day := e.ScheduledDate.Weekday()
+		prod.EntriesByDay[day]++
+
+		dayKey := e.ScheduledDate.Format("2006-01-02")
+		if _, seen := dayCount[day]; !seen {
+			dayCount[day] = 0
+		}
+		_ = dayKey
+	}
+
+	// Calculate unique days per weekday
+	uniqueDays := make(map[time.Weekday]map[string]bool)
+	for _, e := range entries {
+		if e.ScheduledDate == nil {
+			continue
+		}
+		day := e.ScheduledDate.Weekday()
+		if uniqueDays[day] == nil {
+			uniqueDays[day] = make(map[string]bool)
+		}
+		uniqueDays[day][e.ScheduledDate.Format("2006-01-02")] = true
+	}
+
+	// Calculate averages
+	var totalEntries, totalDays int
+	var maxAvg, minAvg float64 = -1, -1
+	var mostDay, leastDay time.Weekday
+
+	for day, count := range prod.EntriesByDay {
+		numDays := len(uniqueDays[day])
+		if numDays == 0 {
+			continue
+		}
+		avg := float64(count) / float64(numDays)
+		totalEntries += count
+		totalDays += numDays
+
+		if maxAvg < 0 || avg > maxAvg {
+			maxAvg = avg
+			mostDay = day
+		}
+		if minAvg < 0 || avg < minAvg {
+			minAvg = avg
+			leastDay = day
+		}
+	}
+
+	if totalDays > 0 {
+		prod.AveragePerDay = float64(totalEntries) / float64(totalDays)
+	}
+
+	if maxAvg >= 0 {
+		prod.MostProductive = domain.Weekday{Day: mostDay, Average: maxAvg}
+	}
+	if minAvg >= 0 {
+		prod.LeastProductive = domain.Weekday{Day: leastDay, Average: minAvg}
+	}
+
+	return prod
+}
+
+func (s *StatsService) calculateHabitStats(ctx context.Context, habits []domain.Habit, logs []domain.HabitLog, today time.Time) domain.HabitStats {
+	stats := domain.HabitStats{
+		Active:    len(habits),
+		TotalLogs: len(logs),
+	}
+
+	if len(habits) == 0 {
+		return stats
+	}
+
+	// Calculate log counts per habit
+	logCounts := make(map[int64]int)
+	for _, l := range logs {
+		logCounts[l.HabitID] += l.Count
+	}
+
+	// Find most logged and best streak
+	var maxCount int
+	var maxStreak int
+
+	for _, h := range habits {
+		count := logCounts[h.ID]
+		if count > maxCount {
+			maxCount = count
+			stats.MostLogged = domain.HabitLogCount{
+				HabitName: h.Name,
+				Count:     count,
+			}
+		}
+
+		// Get all logs for this habit to calculate streak
+		habitLogs, err := s.habitLogRepo.GetByHabitID(ctx, h.ID)
+		if err != nil {
+			continue
+		}
+
+		streak := domain.CalculateStreak(habitLogs, today)
+		if streak > maxStreak {
+			maxStreak = streak
+			stats.BestStreak = domain.HabitStreak{
+				HabitName: h.Name,
+				Days:      streak,
+			}
+		}
+	}
+
+	return stats
+}

--- a/internal/service/stats_test.go
+++ b/internal/service/stats_test.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/typingincolor/bujo/internal/domain"
+)
+
+type mockStatsEntryRepo struct {
+	entries []domain.Entry
+}
+
+func (m *mockStatsEntryRepo) GetByDateRange(ctx context.Context, from, to time.Time) ([]domain.Entry, error) {
+	var result []domain.Entry
+	for _, e := range m.entries {
+		if e.ScheduledDate != nil {
+			if !e.ScheduledDate.Before(from) && !e.ScheduledDate.After(to) {
+				result = append(result, e)
+			}
+		}
+	}
+	return result, nil
+}
+
+type mockStatsHabitRepo struct {
+	habits []domain.Habit
+}
+
+func (m *mockStatsHabitRepo) GetAll(ctx context.Context) ([]domain.Habit, error) {
+	return m.habits, nil
+}
+
+type mockStatsHabitLogRepo struct {
+	logs []domain.HabitLog
+}
+
+func (m *mockStatsHabitLogRepo) GetAllRange(ctx context.Context, start, end time.Time) ([]domain.HabitLog, error) {
+	var result []domain.HabitLog
+	for _, l := range m.logs {
+		if !l.LoggedAt.Before(start) && !l.LoggedAt.After(end) {
+			result = append(result, l)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStatsHabitLogRepo) GetByHabitID(ctx context.Context, habitID int64) ([]domain.HabitLog, error) {
+	var result []domain.HabitLog
+	for _, l := range m.logs {
+		if l.HabitID == habitID {
+			result = append(result, l)
+		}
+	}
+	return result, nil
+}
+
+func TestStatsService_GetStats_EntryCounts(t *testing.T) {
+	today := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	from := today.AddDate(0, 0, -29)
+
+	entries := []domain.Entry{
+		{ID: 1, Type: domain.EntryTypeTask, Content: "Task 1", ScheduledDate: &today},
+		{ID: 2, Type: domain.EntryTypeTask, Content: "Task 2", ScheduledDate: &today},
+		{ID: 3, Type: domain.EntryTypeNote, Content: "Note 1", ScheduledDate: &today},
+		{ID: 4, Type: domain.EntryTypeEvent, Content: "Event 1", ScheduledDate: &today},
+		{ID: 5, Type: domain.EntryTypeDone, Content: "Done 1", ScheduledDate: &today},
+	}
+
+	svc := NewStatsService(
+		&mockStatsEntryRepo{entries: entries},
+		&mockStatsHabitRepo{},
+		&mockStatsHabitLogRepo{},
+	)
+
+	stats, err := svc.GetStats(context.Background(), from, today)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.EntryCounts.Total != 5 {
+		t.Errorf("expected total 5, got %d", stats.EntryCounts.Total)
+	}
+	if stats.EntryCounts.Tasks != 2 {
+		t.Errorf("expected 2 tasks, got %d", stats.EntryCounts.Tasks)
+	}
+	if stats.EntryCounts.Notes != 1 {
+		t.Errorf("expected 1 note, got %d", stats.EntryCounts.Notes)
+	}
+	if stats.EntryCounts.Events != 1 {
+		t.Errorf("expected 1 event, got %d", stats.EntryCounts.Events)
+	}
+	if stats.EntryCounts.Done != 1 {
+		t.Errorf("expected 1 done, got %d", stats.EntryCounts.Done)
+	}
+}
+
+func TestStatsService_GetStats_TaskCompletion(t *testing.T) {
+	today := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	from := today.AddDate(0, 0, -29)
+
+	entries := []domain.Entry{
+		{ID: 1, Type: domain.EntryTypeTask, Content: "Task 1", ScheduledDate: &today},
+		{ID: 2, Type: domain.EntryTypeTask, Content: "Task 2", ScheduledDate: &today},
+		{ID: 3, Type: domain.EntryTypeTask, Content: "Task 3", ScheduledDate: &today},
+		{ID: 4, Type: domain.EntryTypeDone, Content: "Done 1", ScheduledDate: &today},
+		{ID: 5, Type: domain.EntryTypeDone, Content: "Done 2", ScheduledDate: &today},
+		{ID: 6, Type: domain.EntryTypeMigrated, Content: "Migrated 1", ScheduledDate: &today},
+	}
+
+	svc := NewStatsService(
+		&mockStatsEntryRepo{entries: entries},
+		&mockStatsHabitRepo{},
+		&mockStatsHabitLogRepo{},
+	)
+
+	stats, err := svc.GetStats(context.Background(), from, today)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Total tasks = task + done + migrated = 3 + 2 + 1 = 6
+	// Completed = done + migrated = 2 + 1 = 3
+	if stats.TaskCompletion.Total != 6 {
+		t.Errorf("expected total tasks 6, got %d", stats.TaskCompletion.Total)
+	}
+	if stats.TaskCompletion.Completed != 3 {
+		t.Errorf("expected completed 3, got %d", stats.TaskCompletion.Completed)
+	}
+	if stats.TaskCompletion.Rate != 50.0 {
+		t.Errorf("expected rate 50.0, got %.1f", stats.TaskCompletion.Rate)
+	}
+}
+
+func TestStatsService_GetStats_Productivity(t *testing.T) {
+	monday := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // Monday
+	tuesday := monday.AddDate(0, 0, 1)
+	wednesday := monday.AddDate(0, 0, 2)
+	from := monday.AddDate(0, 0, -1)
+	to := wednesday
+
+	entries := []domain.Entry{
+		{ID: 1, Type: domain.EntryTypeTask, Content: "Mon 1", ScheduledDate: &monday},
+		{ID: 2, Type: domain.EntryTypeTask, Content: "Mon 2", ScheduledDate: &monday},
+		{ID: 3, Type: domain.EntryTypeTask, Content: "Mon 3", ScheduledDate: &monday},
+		{ID: 4, Type: domain.EntryTypeTask, Content: "Tue 1", ScheduledDate: &tuesday},
+		{ID: 5, Type: domain.EntryTypeTask, Content: "Wed 1", ScheduledDate: &wednesday},
+	}
+
+	svc := NewStatsService(
+		&mockStatsEntryRepo{entries: entries},
+		&mockStatsHabitRepo{},
+		&mockStatsHabitLogRepo{},
+	)
+
+	stats, err := svc.GetStats(context.Background(), from, to)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.Productivity.MostProductive.Day != time.Monday {
+		t.Errorf("expected most productive Monday, got %v", stats.Productivity.MostProductive.Day)
+	}
+	if stats.Productivity.MostProductive.Average != 3.0 {
+		t.Errorf("expected avg 3.0 for Monday, got %.1f", stats.Productivity.MostProductive.Average)
+	}
+}
+
+func TestStatsService_GetStats_HabitStats(t *testing.T) {
+	today := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	from := today.AddDate(0, 0, -29)
+
+	habits := []domain.Habit{
+		{ID: 1, EntityID: "h1", Name: "Exercise"},
+		{ID: 2, EntityID: "h2", Name: "Read"},
+		{ID: 3, EntityID: "h3", Name: "Meditate"},
+	}
+
+	logs := []domain.HabitLog{
+		{ID: 1, HabitID: 1, Count: 1, LoggedAt: today},
+		{ID: 2, HabitID: 1, Count: 1, LoggedAt: today.AddDate(0, 0, -1)},
+		{ID: 3, HabitID: 1, Count: 1, LoggedAt: today.AddDate(0, 0, -2)},
+		{ID: 4, HabitID: 2, Count: 1, LoggedAt: today},
+		{ID: 5, HabitID: 2, Count: 2, LoggedAt: today.AddDate(0, 0, -1)},
+		{ID: 6, HabitID: 2, Count: 1, LoggedAt: today.AddDate(0, 0, -2)},
+		{ID: 7, HabitID: 2, Count: 1, LoggedAt: today.AddDate(0, 0, -3)},
+		{ID: 8, HabitID: 2, Count: 1, LoggedAt: today.AddDate(0, 0, -4)},
+	}
+
+	svc := NewStatsService(
+		&mockStatsEntryRepo{},
+		&mockStatsHabitRepo{habits: habits},
+		&mockStatsHabitLogRepo{logs: logs},
+	)
+
+	stats, err := svc.GetStats(context.Background(), from, today)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.HabitStats.Active != 3 {
+		t.Errorf("expected 3 active habits, got %d", stats.HabitStats.Active)
+	}
+	if stats.HabitStats.TotalLogs != 8 {
+		t.Errorf("expected 8 total logs, got %d", stats.HabitStats.TotalLogs)
+	}
+	// Read has 5 log entries (most logged)
+	if stats.HabitStats.MostLogged.HabitName != "Read" {
+		t.Errorf("expected most logged habit 'Read', got '%s'", stats.HabitStats.MostLogged.HabitName)
+	}
+	if stats.HabitStats.MostLogged.Count != 6 {
+		t.Errorf("expected most logged count 6, got %d", stats.HabitStats.MostLogged.Count)
+	}
+	// Read has 5 day streak (longest)
+	if stats.HabitStats.BestStreak.HabitName != "Read" {
+		t.Errorf("expected best streak habit 'Read', got '%s'", stats.HabitStats.BestStreak.HabitName)
+	}
+	if stats.HabitStats.BestStreak.Days != 5 {
+		t.Errorf("expected streak 5 days, got %d", stats.HabitStats.BestStreak.Days)
+	}
+}
+
+func TestStatsService_GetStats_EmptyData(t *testing.T) {
+	today := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	from := today.AddDate(0, 0, -29)
+
+	svc := NewStatsService(
+		&mockStatsEntryRepo{},
+		&mockStatsHabitRepo{},
+		&mockStatsHabitLogRepo{},
+	)
+
+	stats, err := svc.GetStats(context.Background(), from, today)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.EntryCounts.Total != 0 {
+		t.Errorf("expected 0 entries, got %d", stats.EntryCounts.Total)
+	}
+	if stats.HabitStats.Active != 0 {
+		t.Errorf("expected 0 habits, got %d", stats.HabitStats.Active)
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -122,3 +122,7 @@ type searchResultsMsg struct {
 	results []domain.Entry
 	query   string
 }
+
+type statsLoadedMsg struct {
+	stats *domain.Stats
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -145,6 +145,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.summaryState.error = msg.err
 		return m, nil
 
+	case statsLoadedMsg:
+		m.statsViewState.loading = false
+		m.statsViewState.stats = msg.stats
+		return m, nil
+
 	case searchResultsMsg:
 		m.searchView.loading = false
 		m.searchView.results = msg.results
@@ -2389,7 +2394,8 @@ func (m Model) handleViewSwitch(msg tea.KeyMsg) (bool, Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keyMap.ViewStats):
 		m.currentView = ViewTypeStats
-		return true, m, nil
+		m.statsViewState.loading = true
+		return true, m, m.loadStatsCmd()
 
 	case key.Matches(msg, m.keyMap.ViewGoals):
 		m.currentView = ViewTypeGoals


### PR DESCRIPTION
## Summary
- Add `bujo stats` CLI command with date range filtering
- Add TUI Stats view (key 6) displaying entry counts, task completion, productivity patterns, and habit statistics
- Implement StatsService with TDD for computing all statistics

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)