### PR TITLE
fix: prevent data loss when editing entries with children and invalid symbols

### DIFF
--- a/internal/domain/parser.go
+++ b/internal/domain/parser.go
@@ -117,7 +117,7 @@ func (p *TreeParser) Parse(input string) ([]Entry, error) {
 		entryType := ParseEntryType(rest)
 
 		if !entryType.IsValid() {
-			return nil, errors.New("unknown entry type symbol")
+			entryType = EntryTypeNote
 		}
 
 		rawContent := ParseContent(rest)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -765,7 +765,7 @@ func TestModel_Update_CaptureMode_DetectsIndentationError(t *testing.T) {
 	}
 }
 
-func TestModel_Update_CaptureMode_DetectsMissingSymbol(t *testing.T) {
+func TestModel_Update_CaptureMode_MissingSymbolDefaultsToNote(t *testing.T) {
 	bujoSvc, habitSvc, listSvc, _ := setupTestServices(t)
 	model := NewWithConfig(Config{
 		BujoService:  bujoSvc,
@@ -773,12 +773,18 @@ func TestModel_Update_CaptureMode_DetectsMissingSymbol(t *testing.T) {
 		ListService:  listSvc,
 	})
 	model.agenda = &service.MultiDayAgenda{}
-	model.captureMode = captureState{active: true, content: "Missing symbol"}
+	model.captureMode = captureState{active: true, content: "Missing symbol text"}
 
 	model.captureMode.parsedEntries, model.captureMode.parseError = model.parseCapture(model.captureMode.content)
 
-	if model.captureMode.parseError == nil {
-		t.Error("expected error for missing symbol prefix")
+	if model.captureMode.parseError != nil {
+		t.Errorf("expected no error for missing symbol prefix (should default to note), got: %v", model.captureMode.parseError)
+	}
+	if len(model.captureMode.parsedEntries) != 1 {
+		t.Errorf("expected 1 parsed entry, got %d", len(model.captureMode.parsedEntries))
+	}
+	if model.captureMode.parsedEntries[0].Type != domain.EntryTypeNote {
+		t.Errorf("expected entry type to be note, got %s", model.captureMode.parsedEntries[0].Type)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix #136**: Editing parent entries now preserves children by cascade-updating `parent_id` references
- **Fix #133, #135**: Invalid entry type symbols now default to notes instead of causing parse errors

## Changes

### Repository Layer
- `Update()` in `entry_repository.go` now cascade-updates children's `parent_id` to point to the new row ID after event sourcing creates a new version

### Service Layer  
- `MoveEntry()`, `updateChildrenDepths()`, and `updateChildrenDates()` now fetch the updated entry's new ID after each `Update()` call before operating on children
- Added `GetByEntityID` to the `EntryRepository` interface

### Domain Layer
- `TreeParser.Parse()` now defaults unknown entry type symbols to `EntryTypeNote` instead of returning an error

## Test plan
- [x] `TestEntryRepository_Update_PreservesChildren` - verifies parent edit preserves children and grandchildren
- [x] `TestTreeParser_Parse_UnknownSymbol_DefaultsToNote` - verifies unknown symbols become notes
- [x] `TestTreeParser_Parse_UnknownSymbol_PreservesHierarchy` - verifies hierarchy preserved with unknown symbols
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)