### PR TITLE
fix: resolve batch A bugs - overdue display, migrated highlight, stats nav

### DIFF
--- a/ISSUE_BATCHES.md
+++ b/ISSUE_BATCHES.md
@@ -1,0 +1,78 @@
+# Issue Batches
+
+Organized batches of open issues for systematic resolution.
+
+## Batch A: Bug Fixes (Quick Wins) - COMPLETE
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #137 | Today's tasks showing as overdue in today view (CLI) | ✅ |
+| #129 | Migrated task row highlight - unreadable foreground text | ✅ |
+| #120 | Summary view: AI navigation bug (pressing "1" goes to today) | ✅ |
+
+## Batch B: TUI Navigation & Usability
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #124 | Keyboard shortcuts to expand/collapse all | ⏳ |
+| #134 | Don't auto-collapse the tree of current working item | ⏳ |
+| #128 | Navigate forwards/backwards in time for day/week view | ⏳ |
+
+## Batch C: CLI Enhancements
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #139 | Add to parent in CLI | ⏳ |
+| #138 | Context in search results | ⏳ |
+| #140 | Need a question entry type | ⏳ |
+
+## Batch D: Core TUI Features
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #122 | Cannot add list in TUI | ⏳ |
+| #123 | Cannot see upcoming tasks in TUI | ⏳ |
+| #121 | Move tasks from journal to lists | ⏳ |
+
+## Batch E: Refactoring (Tech Debt)
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #113 | Replace nested if/else with early returns | ⏳ |
+| #111 | Remove comments from production code | ⏳ |
+| #116 | Extract TUI complex logic into testable functions | ⏳ |
+
+## Batch F: Display & Export
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #132 | Render markdown in AI summaries | ⏳ |
+| #130 | Export entry and children in markdown | ⏳ |
+| #127 | Show work location/mood/weather in views | ⏳ |
+
+## Batch G: Advanced Features
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #126 | Undo last action | ⏳ |
+| #125 | Delete vs strikethrough option | ⏳ |
+| #131 | Priorities in capture mode | ⏳ |
+| #119 | Habit view navigation (previous weeks) | ⏳ |
+
+## Batch H: Architecture & Testing
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #118 | Improve test coverage | ⏳ |
+| #117 | Standardize output streams (12-factor) | ⏳ |
+| #115 | BackupService repository interface | ⏳ |
+| #114 | Extract duplicated CLI/TUI logic | ⏳ |
+| #112 | Immutable state patterns | ⏳ |
+| #104 | Habit log removal fail silently | ⏳ |
+
+---
+
+**Legend:**
+- ✅ Complete
+- 🔄 In Progress
+- ⏳ Pending

--- a/internal/domain/entry.go
+++ b/internal/domain/entry.go
@@ -125,7 +125,9 @@ func (e Entry) IsOverdue(today time.Time) bool {
 	if e.ScheduledDate == nil {
 		return false
 	}
-	return e.ScheduledDate.Before(today)
+	scheduledDate := e.ScheduledDate.Year()*10000 + int(e.ScheduledDate.Month())*100 + e.ScheduledDate.Day()
+	todayDate := today.Year()*10000 + int(today.Month())*100 + today.Day()
+	return scheduledDate < todayDate
 }
 
 func (e Entry) Validate() error {

--- a/internal/domain/entry_test.go
+++ b/internal/domain/entry_test.go
@@ -155,6 +155,16 @@ func TestEntry_IsOverdue(t *testing.T) {
 	}
 }
 
+func TestEntry_IsOverdue_ComparesDateOnly(t *testing.T) {
+	todayMidnight := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+	todayAfternoon := time.Date(2026, 1, 6, 14, 30, 0, 0, time.UTC)
+
+	entry := Entry{Type: EntryTypeTask, ScheduledDate: &todayMidnight}
+
+	assert.False(t, entry.IsOverdue(todayAfternoon),
+		"task scheduled for today should NOT be overdue even when checked later in the day")
+}
+
 func TestEntry_Validate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2267,10 +2267,6 @@ func (m Model) handleCommandPaletteMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleStatsMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if handled, newModel, cmd := m.handleViewSwitch(msg); handled {
-		return newModel, cmd
-	}
-
 	switch {
 	case key.Matches(msg, m.keyMap.Quit):
 		return m, tea.Quit
@@ -2312,6 +2308,10 @@ func (m Model) handleStatsMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.summaryState.refDate = m.navigateSummaryPeriod(1)
 		m.summaryState.summary = nil
 		return m, nil
+	}
+
+	if handled, newModel, cmd := m.handleViewSwitch(msg); handled {
+		return newModel, cmd
 	}
 
 	return m, nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -195,13 +195,10 @@ func (m Model) renderJournalContent() string {
 				linesUsed++
 			}
 
-			line := m.renderEntry(item)
+			line := m.renderEntry(item, i == m.selectedIdx)
 			// Highlight search matches
 			if m.searchMode.active && m.searchMode.query != "" {
 				line = m.highlightSearchTerm(line)
-			}
-			if i == m.selectedIdx {
-				line = SelectedStyle.Render(line)
 			}
 			sb.WriteString(line)
 			sb.WriteString("\n")
@@ -425,7 +422,7 @@ func (m Model) renderListItemsContent() string {
 	return sb.String()
 }
 
-func (m Model) renderEntry(item EntryItem) string {
+func (m Model) renderEntry(item EntryItem, selected bool) string {
 	entry := item.Entry
 	indent := strings.Repeat("  ", item.Indent)
 
@@ -452,6 +449,10 @@ func (m Model) renderEntry(item EntryItem) string {
 		base = fmt.Sprintf("%s%s%s %s %s%s", indent, collapseIndicator, symbol, prioritySymbol, content, hiddenSuffix)
 	} else {
 		base = fmt.Sprintf("%s%s%s %s%s", indent, collapseIndicator, symbol, content, hiddenSuffix)
+	}
+
+	if selected {
+		return SelectedStyle.Render(base)
 	}
 
 	switch entry.Type {


### PR DESCRIPTION
## Summary

Fixes three user-facing bugs identified in Batch A:

- **#137**: Tasks scheduled for today incorrectly appeared overdue when checked later in the day. `IsOverdue()` now compares dates only (year/month/day), not full timestamps.

- **#129**: Selected migrated entries had unreadable text (gray foreground on gray background). `renderEntry()` now accepts a `selected` parameter to avoid nested lipgloss style conflicts.

- **#120**: Pressing "1" in stats/summary view switched to journal instead of selecting daily horizon. Moved `handleViewSwitch()` to end of `handleStatsMode()` so stats-specific keys are handled first.

## Test plan

- [x] Added `TestEntry_IsOverdue_ComparesDateOnly` - verifies date-only comparison
- [x] Added `TestRenderEntry_SelectedMigratedEntry_HasReadableForeground` - verifies no color conflict
- [x] Added `TestRenderEntry_UnselectedMigratedEntry_HasDimStyle` - verifies unselected styling preserved
- [x] Added `TestStatsView_Pressing1_SelectsDailyHorizon_NotJournalView` - verifies horizon selection works
- [x] All existing tests pass (`go test ./...`)

Closes #137, #129, #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)