### PR TITLE
feat: Batch G - TUI Improvements (#104, #119, #125)

### DIFF
--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -41,6 +41,8 @@ type KeyMap struct {
 	RemoveHabitLog  key.Binding
 	DayLeft         key.Binding
 	DayRight        key.Binding
+	PrevPeriod      key.Binding
+	NextPeriod      key.Binding
 	ExpandAll       key.Binding
 	CollapseAll     key.Binding
 }
@@ -198,6 +200,14 @@ func DefaultKeyMap() KeyMap {
 		DayRight: key.NewBinding(
 			key.WithKeys("l", "right"),
 			key.WithHelp("l/→", "next day"),
+		),
+		PrevPeriod: key.NewBinding(
+			key.WithKeys("["),
+			key.WithHelp("[", "prev period"),
+		),
+		NextPeriod: key.NewBinding(
+			key.WithKeys("]"),
+			key.WithHelp("]", "next period"),
 		),
 		ExpandAll: key.NewBinding(
 			key.WithKeys("ctrl+e"),

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1806,7 +1806,7 @@ func (m Model) handleHabitsMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				days = 30
 			}
 			daysAgo := days - 1 - m.habitState.selectedDayIdx
-			logDate := time.Now().AddDate(0, 0, -daysAgo)
+			logDate := m.getHabitReferenceDate().AddDate(0, 0, -daysAgo)
 			return m, m.logHabitForDateCmd(m.habitState.habits[m.habitState.selectedIdx].ID, logDate)
 		}
 		return m, nil
@@ -1834,8 +1834,19 @@ func (m Model) handleHabitsMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				days = 30
 			}
 			daysAgo := days - 1 - m.habitState.selectedDayIdx
-			removeDate := time.Now().AddDate(0, 0, -daysAgo)
+			removeDate := m.getHabitReferenceDate().AddDate(0, 0, -daysAgo)
 			return m, m.removeHabitLogForDateCmd(m.habitState.habits[m.habitState.selectedIdx].ID, removeDate)
+		}
+		return m, nil
+
+	case key.Matches(msg, m.keyMap.PrevPeriod):
+		m.habitState.weekOffset++
+		return m, m.loadHabitsCmd()
+
+	case key.Matches(msg, m.keyMap.NextPeriod):
+		if m.habitState.weekOffset > 0 {
+			m.habitState.weekOffset--
+			return m, m.loadHabitsCmd()
 		}
 		return m, nil
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -331,9 +331,9 @@ func (m Model) renderDayLabels(days int) string {
 	dayNames := []string{"S", "M", "T", "W", "T", "F", "S"}
 	var labels []string
 
-	now := time.Now()
+	referenceDate := m.getHabitReferenceDate()
 	for i := days - 1; i >= 0; i-- {
-		date := now.AddDate(0, 0, -i)
+		date := referenceDate.AddDate(0, 0, -i)
 		dayOfWeek := int(date.Weekday())
 		labels = append(labels, dayNames[dayOfWeek])
 	}


### PR DESCRIPTION
## Summary
Implements three TUI enhancement issues for better user experience:
- Silent failure for habit log removal on empty days (#104)
- Week/month navigation in habit view (#119)
- Strikethrough functionality already exists (#125)

## Changes

### #104: Silent failure when removing non-existent habit logs
- **Problem**: Pressing delete on an empty habit day showed an error message
- **Solution**: Modified `removeHabitLogForDateCmd` to check for "no logs to remove" error and handle it silently
- **Tests**: Added `TestRemoveHabitLogForDateCmd_NoLogsToRemove_ShouldNotReturnError`

### #119: Habit view navigation
- **Problem**: No way to view previous weeks/months in habit tracker
- **Solution**: 
  - Added `weekOffset` field to `habitState` (0 = current period, 1+ = previous periods)
  - Added `[` key to navigate to previous periods, `]` to navigate forward (cannot go to future)
  - Updated data loading, rendering, and all date calculations to respect offset
  - Extracted `getHabitReferenceDate()` helper for DRY
- **Tests**: Added comprehensive navigation tests

### #125: Strikethrough functionality
- **Status**: Already implemented via `CancelEntry` ('x' key) and `UncancelEntry` ('X' key)
- **Tests**: Existing UAT tests verify functionality

## Test plan
- [x] All existing tests pass
- [x] New tests added for #104 and #119
- [x] Verified #125 functionality via existing tests
- [x] Manual testing: habit navigation works correctly
- [x] Manual testing: silent failure on empty habit days

🤖 Generated with [Claude Code](https://claude.com/claude-code)