### PR TITLE
fix: Improve Ollama summary quality and optimize CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,32 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Download dependencies
-        run: go mod tidy
-
-      - name: Run tests
-        run: go test -v -coverprofile=coverage.out ./...
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+  # Fast feedback: lint runs in parallel with tests
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -58,9 +33,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Tidy modules
-        run: go mod tidy
-
       - name: Run go vet
         run: go vet ./...
 
@@ -69,13 +41,10 @@ jobs:
         with:
           version: latest
 
-  build:
-    name: Build
-    needs: [test, lint]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  # Primary test job - ubuntu only for PRs (fast), both OS for main
+  test:
+    name: Test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -85,8 +54,62 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Tidy modules
-        run: go mod tidy
+      - name: Run tests
+        run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # macOS test - only on main branch pushes and tags
+  test-macos:
+    name: Test (macOS)
+    if: github.event_name == 'push'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test -v ./...
+
+  # Build verification - only needs lint to pass (tests run in parallel)
+  build:
+    name: Build
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build -v ./cmd/bujo
+
+  # macOS build - only on main branch
+  build-macos:
+    name: Build (macOS)
+    if: github.event_name == 'push'
+    needs: [lint]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Build
         run: go build -v ./cmd/bujo

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mutate:
-    name: Mutation Testing
+  mutate-domain:
+    name: Mutate Domain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,14 +25,26 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Tidy modules
-        run: go mod tidy
-
       - name: Install gremlins
         run: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
 
       - name: Run mutation testing on domain
         run: gremlins unleash ./internal/domain
+
+  mutate-service:
+    name: Mutate Service
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
 
       - name: Run mutation testing on service
         run: gremlins unleash ./internal/service

--- a/cmd/bujo/cmd/summary.go
+++ b/cmd/bujo/cmd/summary.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,6 +53,10 @@ Examples:
 			fmt.Print(token)
 		})
 		if err != nil {
+			if errors.Is(err, domain.ErrNoEntries) {
+				fmt.Println("No entries to summarize for this period.")
+				return nil
+			}
 			return fmt.Errorf("failed to generate summary: %w", err)
 		}
 

--- a/docs/AI_SETUP.md
+++ b/docs/AI_SETUP.md
@@ -37,11 +37,11 @@ brew services stop ollama
 # List available models
 ollama list
 
-# Download the recommended model (1.3 GB)
-ollama pull llama3.2:1b
+# Download the recommended model (2.0 GB) - good balance of quality and speed
+ollama pull llama3.2:3b
 
-# Or try the smallest model for testing (637 MB)
-ollama pull tinyllama
+# Or try the smaller model if low on disk space (1.3 GB) - lower quality
+ollama pull llama3.2:1b
 ```
 
 ### 4. Use AI Features
@@ -165,8 +165,8 @@ export BUJO_AI_PROVIDER=gemini
 ### Local Model Configuration
 
 ```bash
-# Specify which model to use (default: llama3.2:1b)
-export BUJO_MODEL=tinyllama
+# Specify which model to use (default: llama3.2:3b)
+export BUJO_MODEL=llama3.2:3b
 ```
 
 Ollama manages model storage automatically in `~/.ollama/models/`.
@@ -176,7 +176,7 @@ Ollama manages model storage automatically in `~/.ollama/models/`.
 **Local AI only:**
 ```bash
 export BUJO_AI_PROVIDER=local
-export BUJO_MODEL=llama3.2:1b
+export BUJO_MODEL=llama3.2:3b
 ```
 
 **Gemini only:**
@@ -210,7 +210,7 @@ ollama pull tinyllama
 Ollama's registry servers are temporarily unavailable. This is a server-side issue. Wait a few minutes and retry:
 
 ```bash
-ollama pull llama3.2:1b
+ollama pull llama3.2:3b
 ```
 
 ### "failed to create Ollama client: ... (is Ollama running?)"
@@ -279,10 +279,10 @@ bujo supports several curated models optimized for journal summaries:
 
 | Model | Size | Quality | Speed | Memory |
 |-------|------|---------|-------|--------|
-| tinyllama | 637 MB | Good | Fast | 1 GB RAM |
-| llama3.2:1b | 1.3 GB | Better | Fast | 2 GB RAM |
-| llama3.2:3b | 2.0 GB | Best | Medium | 4 GB RAM |
-| phi-3-mini | 2.3 GB | Better | Fast | 3 GB RAM |
+| tinyllama | 637 MB | Poor | Fast | 1 GB RAM |
+| llama3.2:1b | 1.3 GB | Fair | Fast | 2 GB RAM |
+| llama3.2:3b | 2.0 GB | Good (Recommended) | Medium | 4 GB RAM |
+| phi-3-mini | 2.3 GB | Good | Fast | 3 GB RAM |
 | mistral:7b | 4.1 GB | Excellent | Slow | 8 GB RAM |
 
 ### Gemini Model

--- a/internal/adapter/ai/config.go
+++ b/internal/adapter/ai/config.go
@@ -39,7 +39,7 @@ func NewAIClient(ctx context.Context) (GenAIClient, error) {
 func newLocalClient(ctx context.Context) (GenAIClient, error) {
 	modelName := os.Getenv("BUJO_MODEL")
 	if modelName == "" {
-		modelName = "llama3.2:1b"
+		modelName = "llama3.2:3b"
 	}
 
 	return local.NewLocalClient(modelName)

--- a/internal/adapter/ai/local/client.go
+++ b/internal/adapter/ai/local/client.go
@@ -36,7 +36,7 @@ func (c *LocalClient) Generate(ctx context.Context, prompt string) (string, erro
 		Prompt: prompt,
 		Stream: new(bool),
 		Options: map[string]interface{}{
-			"temperature": 0.7,
+			"temperature": 0.4,
 			"top_p":       0.9,
 		},
 	}
@@ -58,7 +58,7 @@ func (c *LocalClient) GenerateStream(ctx context.Context, prompt string, callbac
 		Model:  c.modelName,
 		Prompt: prompt,
 		Options: map[string]interface{}{
-			"temperature": 0.7,
+			"temperature": 0.4,
 			"top_p":       0.9,
 		},
 	}

--- a/internal/domain/summary.go
+++ b/internal/domain/summary.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var ErrNoEntries = errors.New("no entries to summarize")
+
 type SummaryHorizon string
 
 const (

--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -61,6 +61,10 @@ func (s *SummaryService) GetSummaryWithRefresh(ctx context.Context, horizon doma
 		return nil, err
 	}
 
+	if len(entries) == 0 {
+		return nil, domain.ErrNoEntries
+	}
+
 	content, err := s.generator.GenerateSummary(ctx, entries, horizon)
 	if err != nil {
 		return nil, err
@@ -100,6 +104,10 @@ func (s *SummaryService) CheckCacheOrGenerate(ctx context.Context, horizon domai
 	entries, err := s.entryRepo.GetByDateRange(ctx, startDate, endDate)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(entries) == 0 {
+		return nil, domain.ErrNoEntries
 	}
 
 	var contentBuilder strings.Builder

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -1244,7 +1245,12 @@ func (m Model) renderJournalAISummary() string {
 	} else if m.summaryState.loading {
 		sb.WriteString("⏳ Generating AI summary...\n")
 	} else if m.summaryState.error != nil {
-		sb.WriteString(fmt.Sprintf("❌ Error: %v\n", m.summaryState.error))
+		if errors.Is(m.summaryState.error, domain.ErrNoEntries) {
+			sb.WriteString(HelpStyle.Render("No entries to summarize for this period"))
+			sb.WriteString("\n")
+		} else {
+			sb.WriteString(fmt.Sprintf("❌ Error: %v\n", m.summaryState.error))
+		}
 	} else {
 		sb.WriteString(HelpStyle.Render("No summary generated for this period"))
 		sb.WriteString("\n")


### PR DESCRIPTION
## Summary

- **Fix gibberish Ollama output**: Change default model from `llama3.2:1b` to `llama3.2:3b` and lower temperature from 0.7 to 0.4
- **Skip AI for empty periods**: Return `ErrNoEntries` instead of calling Ollama when no entries exist
- **Optimize CI workflows**: Run jobs in parallel, skip macOS tests on PRs

## Changes

### Ollama Quality Fixes
- Default model: `llama3.2:1b` → `llama3.2:3b` (better instruction following)
- Temperature: `0.7` → `0.4` (more coherent output)
- Added `ErrNoEntries` sentinel error in domain layer
- Service layer checks for empty entries before calling AI
- CLI/TUI handle empty entries gracefully with friendly message

### CI Optimizations
- Lint and test now run in **parallel** (was sequential)
- PRs: ubuntu only | Main pushes: ubuntu + macOS
- Build only waits for lint (test runs alongside)
- Mutation testing: domain + service run in parallel

## Test plan

- [x] Manual test: empty date shows "No entries to summarize"
- [x] Manual test: date with entries generates coherent summary
- [x] All unit tests pass
- [x] Pre-push hooks pass (gofmt, vet, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)