### PR TITLE
docs: Update README and suppress add command ID output

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ bujo summary daily
 ```
 
 **Configuration:**
+- AI features are disabled by default. Set `BUJO_AI_ENABLED=true` to enable
 - Local AI is used by default if a model is downloaded
 - Set `BUJO_AI_PROVIDER=gemini` to force Gemini
 - Set `BUJO_AI_PROVIDER=local` to force local AI
@@ -194,7 +195,7 @@ bujo view 42 --up 1    # Show grandparent context
 
 #### `bujo add [entries...]`
 
-Add entries to today's journal. Returns the ID of each entry.
+Add entries to today's journal.
 
 ```bash
 bujo add ". Call mom"                    # Single entry
@@ -677,8 +678,11 @@ j/k: move  space: done  x: cancel  d: delete  q: quit  ?: help
 | `Ctrl+P` | Open command palette |
 | `Ctrl+S` | Search forward |
 | `Ctrl+R` | Search reverse |
+| `@` | Set location for current day |
+| `s` | Toggle AI summary collapse/expand |
+| `Esc` | Navigate back through view stack |
 | `?` | Toggle help |
-| `q` | Quit |
+| `q` | Quit (shows confirmation dialog) |
 
 **Habits View shortcuts:**
 

--- a/cmd/bujo/cmd/add.go
+++ b/cmd/bujo/cmd/add.go
@@ -101,10 +101,6 @@ Examples:
 			return fmt.Errorf("failed to add entries: %w", err)
 		}
 
-		for _, id := range ids {
-			fmt.Println(id)
-		}
-
 		fmt.Fprintf(os.Stderr, "Added %d entry(s)\n", len(ids))
 		return nil
 	},


### PR DESCRIPTION
## Summary

- Document new TUI keybindings in README: `@` (set location), `s` (toggle AI summary), `Esc` (navigate back)
- Document `BUJO_AI_ENABLED` environment variable in configuration section
- Clarify that `q` shows quit confirmation dialog
- Remove entry ID output from `bujo add` command (users don't need these IDs)
- Update add command description to not mention ID output

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Pre-push hooks pass (gofmt, go vet, golangci-lint)

## Related Issues

Closes #191
Closes #171
Note: #183 was already implemented via `M` key (convert task to goal)

🤖 Generated with [Claude Code](https://claude.ai/code)