### PR TITLE
fix: Preserve entry position when editing (#193)

### DIFF
--- a/internal/domain/entity_id.go
+++ b/internal/domain/entity_id.go
@@ -9,7 +9,11 @@ import (
 type EntityID string
 
 func NewEntityID() EntityID {
-	return EntityID(uuid.New().String())
+	id, err := uuid.NewV7()
+	if err != nil {
+		return EntityID(uuid.New().String())
+	}
+	return EntityID(id.String())
 }
 
 func ParseEntityID(s string) (EntityID, error) {

--- a/internal/repository/sqlite/entry_repository.go
+++ b/internal/repository/sqlite/entry_repository.go
@@ -83,7 +83,7 @@ func (r *EntryRepository) GetByDate(ctx context.Context, date time.Time) ([]doma
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, type, content, priority, parent_id, depth, location, scheduled_date, created_at, entity_id
 		FROM entries WHERE scheduled_date = ? AND (valid_to IS NULL OR valid_to = '')
-		ORDER BY created_at
+		ORDER BY created_at, entity_id
 	`, dateStr)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (r *EntryRepository) GetByDateRange(ctx context.Context, from, to time.Time
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, type, content, priority, parent_id, depth, location, scheduled_date, created_at, entity_id
 		FROM entries WHERE scheduled_date >= ? AND scheduled_date <= ? AND (valid_to IS NULL OR valid_to = '') AND op_type != 'DELETE'
-		ORDER BY scheduled_date, created_at
+		ORDER BY scheduled_date, created_at, entity_id
 	`, fromStr, toStr)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (r *EntryRepository) GetOverdue(ctx context.Context, date time.Time) ([]dom
 		)
 		SELECT DISTINCT id, type, content, priority, parent_id, depth, location, scheduled_date, created_at, entity_id
 		FROM parent_chain
-		ORDER BY scheduled_date, depth, created_at
+		ORDER BY scheduled_date, depth, created_at, entity_id
 	`, dateStr)
 	if err != nil {
 		return nil, err
@@ -528,7 +528,7 @@ func (r *EntryRepository) GetAll(ctx context.Context) ([]domain.Entry, error) {
 		SELECT id, type, content, priority, parent_id, depth, location, scheduled_date, created_at, entity_id
 		FROM entries
 		WHERE (valid_to IS NULL OR valid_to = '') AND op_type != 'DELETE'
-		ORDER BY scheduled_date, created_at
+		ORDER BY scheduled_date, created_at, entity_id
 	`)
 	if err != nil {
 		return nil, err
@@ -562,7 +562,7 @@ func (r *EntryRepository) Search(ctx context.Context, opts domain.SearchOptions)
 		args = append(args, opts.DateFrom.Format("2006-01-02"), opts.DateTo.Format("2006-01-02"))
 	}
 
-	query += ` ORDER BY scheduled_date DESC, created_at DESC`
+	query += ` ORDER BY scheduled_date DESC, created_at DESC, entity_id DESC`
 
 	limit := opts.Limit
 	if limit <= 0 {


### PR DESCRIPTION
## Summary
- Fixes entries losing their position in the list after being edited
- Uses UUID v7 (time-sortable) for new entity IDs instead of random UUID v4
- Adds `entity_id` as secondary sort key in queries for stable ordering

## Root Cause
Entries were ordered by `created_at` which only has second precision. When multiple entries shared the same timestamp, SQLite's ordering was non-deterministic. After an update (which creates a new row via event sourcing), entries could appear in different positions.

## Backward Compatibility
- Existing entries with UUID v4 will maintain stable (though arbitrary) order
- New entries with UUID v7 will sort in creation order
- No migration needed - the fix prevents entries from moving after edits

## Test plan
- [x] Added `TestEntryRepository_Update_PreservesOrder` that creates entries with identical timestamps and verifies order is preserved after updates
- [x] All existing tests pass
- [x] Linting passes

Closes #193

🤖 Generated with [Claude Code](https://claude.ai/code)