### PR TITLE
feat(frontend): Add Capture Mode for multi-line entry creation (Sprint 8)

### DIFF
--- a/frontend/src/components/bujo/CaptureModal.test.tsx
+++ b/frontend/src/components/bujo/CaptureModal.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CaptureModal } from './CaptureModal'
+
+vi.mock('@/wailsjs/go/wails/App', () => ({
+  AddEntry: vi.fn().mockResolvedValue([1]),
+}))
+
+import { AddEntry } from '@/wailsjs/go/wails/App'
+
+const mockStorage: Record<string, string> = {}
+const mockLocalStorage = {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => { mockStorage[key] = value }),
+  removeItem: vi.fn((key: string) => { delete mockStorage[key] }),
+  clear: vi.fn(() => { Object.keys(mockStorage).forEach(key => delete mockStorage[key]) }),
+}
+
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage })
+
+describe('CaptureModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLocalStorage.clear()
+  })
+
+  afterEach(() => {
+    mockLocalStorage.clear()
+  })
+
+  it('renders nothing when not open', () => {
+    const { container } = render(
+      <CaptureModal isOpen={false} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders modal when open', () => {
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+    expect(screen.getByText('Capture Entries')).toBeInTheDocument()
+  })
+
+  it('renders textarea for multi-line input', () => {
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+    expect(screen.getByPlaceholderText(/enter entries/i)).toBeInTheDocument()
+  })
+
+  it('shows syntax help', () => {
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+    expect(screen.getByText(/task/i)).toBeInTheDocument()
+    expect(screen.getByText(/note/i)).toBeInTheDocument()
+    expect(screen.getByText(/event/i)).toBeInTheDocument()
+  })
+
+  it('calls AddEntry binding when submitting', async () => {
+    const onEntriesCreated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={onEntriesCreated} />
+    )
+
+    const textarea = screen.getByPlaceholderText(/enter entries/i)
+    await user.type(textarea, '. Buy groceries{enter}- Remember to check expiry')
+    await user.click(screen.getByText('Save Entries'))
+
+    await waitFor(() => {
+      expect(AddEntry).toHaveBeenCalled()
+    })
+  })
+
+  it('calls onEntriesCreated after successful submission', async () => {
+    const onEntriesCreated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={onEntriesCreated} />
+    )
+
+    const textarea = screen.getByPlaceholderText(/enter entries/i)
+    await user.type(textarea, '. Test entry')
+    await user.click(screen.getByText('Save Entries'))
+
+    await waitFor(() => {
+      expect(onEntriesCreated).toHaveBeenCalled()
+    })
+  })
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CaptureModal isOpen={true} onClose={onClose} onEntriesCreated={() => {}} />
+    )
+
+    await user.click(screen.getByText('Cancel'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables save when textarea is empty', () => {
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+
+    const saveButton = screen.getByText('Save Entries')
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('clears textarea after successful submission', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+    )
+
+    const textarea = screen.getByPlaceholderText(/enter entries/i)
+    await user.type(textarea, '. Test entry')
+    await user.click(screen.getByText('Save Entries'))
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('')
+    })
+  })
+
+  describe('draft auto-save', () => {
+    it('saves draft to localStorage as user types', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+      )
+
+      const textarea = screen.getByPlaceholderText(/enter entries/i)
+      await user.type(textarea, '. Draft entry')
+
+      await waitFor(() => {
+        expect(mockLocalStorage.setItem).toHaveBeenCalledWith('bujo-capture-draft', '. Draft entry')
+      })
+    })
+
+    it('restores draft from localStorage on open', () => {
+      mockStorage['bujo-capture-draft'] = '. Saved draft'
+
+      render(
+        <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+      )
+
+      const textarea = screen.getByPlaceholderText(/enter entries/i)
+      expect(textarea).toHaveValue('. Saved draft')
+    })
+
+    it('clears draft from localStorage after successful save', async () => {
+      mockStorage['bujo-capture-draft'] = '. Draft to clear'
+      const user = userEvent.setup()
+
+      render(
+        <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+      )
+
+      await user.click(screen.getByText('Save Entries'))
+
+      await waitFor(() => {
+        expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('bujo-capture-draft')
+      })
+    })
+  })
+
+  describe('syntax support', () => {
+    it('shows indentation creates hierarchy hint', () => {
+      render(
+        <CaptureModal isOpen={true} onClose={() => {}} onEntriesCreated={() => {}} />
+      )
+      expect(screen.getByText(/indent/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/bujo/CaptureModal.tsx
+++ b/frontend/src/components/bujo/CaptureModal.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { AddEntry } from '@/wailsjs/go/wails/App'
+import { time } from '@/wailsjs/go/models'
+import { startOfDay } from '@/lib/utils'
+
+interface CaptureModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onEntriesCreated: () => void
+}
+
+const DRAFT_KEY = 'bujo-capture-draft'
+
+function toWailsTime(date: Date): time.Time {
+  return date.toISOString() as unknown as time.Time
+}
+
+export function CaptureModal({
+  isOpen,
+  onClose,
+  onEntriesCreated,
+}: CaptureModalProps) {
+  const [content, setContent] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      const draft = localStorage.getItem(DRAFT_KEY)
+      if (draft) {
+        setContent(draft)
+      }
+    }
+  }, [isOpen])
+
+  const saveDraft = useCallback((text: string) => {
+    if (text) {
+      localStorage.setItem(DRAFT_KEY, text)
+    } else {
+      localStorage.removeItem(DRAFT_KEY)
+    }
+  }, [])
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newContent = e.target.value
+    setContent(newContent)
+    saveDraft(newContent)
+  }
+
+  if (!isOpen) return null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!content.trim()) return
+
+    setIsSubmitting(true)
+    try {
+      const today = startOfDay(new Date())
+      await AddEntry(content.trim(), toWailsTime(today))
+      setContent('')
+      localStorage.removeItem(DRAFT_KEY)
+      onEntriesCreated()
+    } catch (err) {
+      console.error('Failed to create entries:', err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative z-10 w-full max-w-2xl bg-card border rounded-lg shadow-lg p-6 mx-4 max-h-[80vh] flex flex-col">
+        <h2 className="text-lg font-display font-semibold mb-4">Capture Entries</h2>
+
+        {/* Syntax help */}
+        <div className="mb-4 p-3 bg-secondary/50 rounded-md text-sm">
+          <div className="font-medium mb-2">Entry Prefixes:</div>
+          <div className="grid grid-cols-2 gap-2 text-muted-foreground">
+            <div><code className="bg-muted px-1 rounded">.</code> Task</div>
+            <div><code className="bg-muted px-1 rounded">-</code> Note</div>
+            <div><code className="bg-muted px-1 rounded">o</code> Event</div>
+            <div><code className="bg-muted px-1 rounded">?</code> Question</div>
+          </div>
+          <div className="mt-2 text-muted-foreground">
+            <span className="font-medium">Tip:</span> Indent with spaces/tabs to create child entries.
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex-1 flex flex-col">
+          <textarea
+            value={content}
+            onChange={handleContentChange}
+            placeholder="Enter entries (one per line)..."
+            rows={10}
+            className={cn(
+              'w-full flex-1 px-3 py-2 rounded-md border bg-background',
+              'focus:outline-none focus:ring-2 focus:ring-primary',
+              'placeholder:text-muted-foreground text-sm font-mono resize-none'
+            )}
+            autoFocus
+          />
+
+          <div className="flex justify-end gap-3 mt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded-md border hover:bg-secondary transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!content.trim() || isSubmitting}
+              className={cn(
+                'px-4 py-2 text-sm rounded-md transition-colors',
+                content.trim() && !isSubmitting
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'bg-muted text-muted-foreground cursor-not-allowed'
+              )}
+            >
+              {isSubmitting ? 'Saving...' : 'Save Entries'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/bujo/Header.test.tsx
+++ b/frontend/src/components/bujo/Header.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Header } from './Header'
+
+describe('Header', () => {
+  it('renders title', () => {
+    render(<Header title="Today" />)
+    expect(screen.getByText('Today')).toBeInTheDocument()
+  })
+
+  it('renders search input', () => {
+    render(<Header title="Today" />)
+    expect(screen.getByPlaceholderText(/search entries/i)).toBeInTheDocument()
+  })
+
+  it('renders current date', () => {
+    render(<Header title="Today" />)
+    const formattedDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+    expect(screen.getByText(formattedDate)).toBeInTheDocument()
+  })
+
+  it('renders capture button', () => {
+    render(<Header title="Today" onCapture={() => {}} />)
+    expect(screen.getByTitle('Capture entries')).toBeInTheDocument()
+  })
+
+  it('calls onCapture when capture button is clicked', () => {
+    const onCapture = vi.fn()
+    render(<Header title="Today" onCapture={onCapture} />)
+
+    fireEvent.click(screen.getByTitle('Capture entries'))
+    expect(onCapture).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render capture button when onCapture not provided', () => {
+    render(<Header title="Today" />)
+    expect(screen.queryByTitle('Capture entries')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/bujo/Header.tsx
+++ b/frontend/src/components/bujo/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { format } from 'date-fns';
-import { Calendar, Search, Command } from 'lucide-react';
+import { Calendar, Search, Command, FileEdit } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const SEARCH_DEBOUNCE_MS = 200;
@@ -17,9 +17,10 @@ interface HeaderProps {
   searchResults?: SearchResult[];
   onSearch?: (query: string) => void;
   onSelectResult?: (result: SearchResult) => void;
+  onCapture?: () => void;
 }
 
-export function Header({ title, searchResults = [], onSearch, onSelectResult }: HeaderProps) {
+export function Header({ title, searchResults = [], onSearch, onSelectResult, onCapture }: HeaderProps) {
   const today = new Date();
   const [query, setQuery] = useState('');
   const [showResults, setShowResults] = useState(false);
@@ -73,6 +74,20 @@ export function Header({ title, searchResults = [], onSearch, onSelectResult }: 
       </div>
 
       <div className="flex items-center gap-3">
+        {/* Capture button */}
+        {onCapture && (
+          <button
+            onClick={onCapture}
+            title="Capture entries"
+            className={cn(
+              'p-2 rounded-lg transition-colors',
+              'bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <FileEdit className="w-4 h-4" />
+          </button>
+        )}
+
         {/* Search */}
         <div className="relative">
           <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Add CaptureModal for bulk entry creation with multi-line textarea input
- Support TreeParser syntax: entry prefixes (. task, - note, o event, ? question) and indentation for hierarchy
- Implement draft auto-save to localStorage to prevent data loss
- Add Capture button to Header for quick access to capture mode
- Add comprehensive test coverage for CaptureModal (13 tests) and Header (6 tests)

Closes #278, #279, #280, #281, #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)