### PR TITLE
feat(habits): Add extended habit management features (Sprint 9)

### DIFF
--- a/frontend/src/wailsjs/go/wails/App.d.ts
+++ b/frontend/src/wailsjs/go/wails/App.d.ts
@@ -52,3 +52,9 @@ export function RemoveListItem(arg1:number):Promise<void>;
 export function Search(arg1:string):Promise<Array<domain.Entry>>;
 
 export function AnswerQuestion(arg1:number,arg2:string):Promise<void>;
+
+export function LogHabitForDate(arg1:number,arg2:number,arg3:time.Time):Promise<void>;
+
+export function UndoHabitLog(arg1:number):Promise<void>;
+
+export function SetHabitGoal(arg1:number,arg2:number):Promise<void>;

--- a/frontend/src/wailsjs/go/wails/App.js
+++ b/frontend/src/wailsjs/go/wails/App.js
@@ -97,3 +97,15 @@ export function Search(arg1) {
 export function AnswerQuestion(arg1, arg2) {
   return window['go']['wails']['App']['AnswerQuestion'](arg1, arg2);
 }
+
+export function LogHabitForDate(arg1, arg2, arg3) {
+  return window['go']['wails']['App']['LogHabitForDate'](arg1, arg2, arg3);
+}
+
+export function UndoHabitLog(arg1) {
+  return window['go']['wails']['App']['UndoHabitLog'](arg1);
+}
+
+export function SetHabitGoal(arg1, arg2) {
+  return window['go']['wails']['App']['SetHabitGoal'](arg1, arg2);
+}

--- a/internal/adapter/wails/app.go
+++ b/internal/adapter/wails/app.go
@@ -140,6 +140,18 @@ func (a *App) DeleteHabit(habitID int64) error {
 	return a.services.Habit.DeleteHabitByID(a.ctx, habitID)
 }
 
+func (a *App) LogHabitForDate(habitID int64, count int, date time.Time) error {
+	return a.services.Habit.LogHabitByIDForDate(a.ctx, habitID, count, date)
+}
+
+func (a *App) UndoHabitLog(habitID int64) error {
+	return a.services.Habit.UndoLastLogByID(a.ctx, habitID)
+}
+
+func (a *App) SetHabitGoal(habitID int64, dailyGoal int) error {
+	return a.services.Habit.SetHabitGoalByID(a.ctx, habitID, dailyGoal)
+}
+
 func (a *App) AnswerQuestion(questionID int64, answerText string) error {
 	return a.services.Bujo.MarkAnswered(a.ctx, questionID, answerText)
 }


### PR DESCRIPTION
## Summary
- Add period view toggle (week/month/quarter) for habit tracking visualization
- Add undo functionality for logged habits with UndoHabitLog binding
- Add habit goal setting with SetHabitGoal binding and inline input
- Add retroactive logging for specific dates via LogHabitForDate binding

Implements Phase 6 Sprint 9: Extended Habits (#283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)