### PR TITLE
feat: Add 'Go to today' button and T keyboard shortcut in journal view

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1313,6 +1313,107 @@ describe('App - Inline Entry Creation (a/A/r shortcuts)', () => {
   })
 })
 
+describe('App - Go to Today', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(GetAgenda).mockResolvedValue(mockEntriesAgenda)
+  })
+
+  it('shows Go to today button when viewing a different day', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('First task')).toBeInTheDocument()
+    })
+
+    // Navigate to previous day
+    const prevButton = screen.getByRole('button', { name: /previous day/i })
+    await user.click(prevButton)
+
+    // Go to today button should appear (distinct from sidebar Today nav button)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /go to today/i })).toBeInTheDocument()
+    })
+  })
+
+  it('hides Go to today button when viewing today', async () => {
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('First task')).toBeInTheDocument()
+    })
+
+    // Go to today button should NOT be visible when viewing today
+    expect(screen.queryByRole('button', { name: /go to today/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking Go to today button navigates back to today', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('First task')).toBeInTheDocument()
+    })
+
+    // Navigate to previous day
+    const prevButton = screen.getByRole('button', { name: /previous day/i })
+    await user.click(prevButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /go to today/i })).toBeInTheDocument()
+    })
+
+    vi.mocked(GetAgenda).mockClear()
+
+    // Click Go to today button
+    const todayButton = screen.getByRole('button', { name: /go to today/i })
+    await user.click(todayButton)
+
+    // Should trigger data refresh
+    await waitFor(() => {
+      expect(GetAgenda).toHaveBeenCalled()
+    })
+
+    // Go to today button should disappear after navigating back to today
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /go to today/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('pressing T navigates to today when viewing a different day', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('First task')).toBeInTheDocument()
+    })
+
+    // Navigate to previous day
+    const prevButton = screen.getByRole('button', { name: /previous day/i })
+    await user.click(prevButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /go to today/i })).toBeInTheDocument()
+    })
+
+    vi.mocked(GetAgenda).mockClear()
+
+    // Press T to go to today
+    await user.keyboard('T')
+
+    // Should trigger data refresh
+    await waitFor(() => {
+      expect(GetAgenda).toHaveBeenCalled()
+    })
+
+    // Go to today button should disappear
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /go to today/i })).not.toBeInTheDocument()
+    })
+  })
+})
+
 describe('App - Review View (formerly Past Week)', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,6 +151,10 @@ function App() {
     })
   }, [])
 
+  const handleGoToToday = useCallback(() => {
+    setCurrentDate(startOfDay(new Date()))
+  }, [])
+
   const handlePrevWeek = useCallback(() => {
     setReviewAnchorDate(prev => {
       const newDate = new Date(prev)
@@ -206,7 +210,7 @@ function App() {
 
       if (isInputFocused) return
 
-      // Day navigation shortcuts (h/l) - always available in today view
+      // Day navigation shortcuts (h/l/T) - always available in today view
       if (view === 'today') {
         if (e.key === 'h') {
           e.preventDefault()
@@ -216,6 +220,11 @@ function App() {
         if (e.key === 'l') {
           e.preventDefault()
           handleNextDay()
+          return
+        }
+        if (e.key === 'T') {
+          e.preventDefault()
+          handleGoToToday()
           return
         }
       }
@@ -306,7 +315,7 @@ function App() {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [view, flatEntries, selectedIndex, loadData, handleDeleteEntryRequest, handlePrevDay, handleNextDay, cycleHabitPeriod])
+  }, [view, flatEntries, selectedIndex, loadData, handleDeleteEntryRequest, handlePrevDay, handleNextDay, handleGoToToday, cycleHabitPeriod])
 
   useEffect(() => {
     setSelectedIndex(0)
@@ -435,6 +444,7 @@ function App() {
 
   const today = days[0]
   const selectedEntryId = flatEntries[selectedIndex]?.id ?? null
+  const isViewingToday = currentDate.toDateString() === new Date().toDateString()
 
   return (
     <div className="flex h-screen bg-background">
@@ -477,6 +487,15 @@ function App() {
                 >
                   <ChevronRight className="w-5 h-5" />
                 </button>
+                {!isViewingToday && (
+                  <button
+                    onClick={handleGoToToday}
+                    aria-label="Go to today"
+                    className="px-3 py-2 text-sm rounded-lg bg-primary/10 hover:bg-primary/20 text-primary transition-colors"
+                  >
+                    Today
+                  </button>
+                )}
                 <button
                   onClick={() => setShowCaptureModal(true)}
                   title="Open capture modal"

--- a/frontend/src/components/bujo/KeyboardShortcuts.tsx
+++ b/frontend/src/components/bujo/KeyboardShortcuts.tsx
@@ -45,6 +45,7 @@ export function KeyboardShortcuts({ view = 'today' }: KeyboardShortcutsProps) {
           <KeyboardHint keys={['k', '↑']} action="Move up" />
           <KeyboardHint keys={['h']} action="Previous day" />
           <KeyboardHint keys={['l']} action="Next day" />
+          <KeyboardHint keys={['T']} action="Go to today" />
           <KeyboardHint keys={['Space']} action="Toggle done" />
           <KeyboardHint keys={['x']} action="Cancel/uncancel" />
           <KeyboardHint keys={['p']} action="Cycle priority" />


### PR DESCRIPTION
## Summary
- Adds a "Today" button in the journal view navigation that appears when viewing a day other than today
- Adds `T` keyboard shortcut for quick navigation back to today
- Updates KeyboardShortcuts panel to document the new shortcut

Closes #73

## Test plan
- [ ] Navigate to a different day using prev/next arrows - "Today" button should appear
- [ ] Click "Today" button - should navigate back to current date
- [ ] Press `T` key while viewing a different day - should navigate back to today
- [ ] Verify button is hidden when already viewing today
- [ ] Press `?` to verify new shortcut appears in keyboard shortcuts panel

🤖 Generated with [Claude Code](https://claude.ai/claude-code)