### PR TITLE
fix: TUI improvements for issues #67, #68, #70, #71

### DIFF
--- a/internal/tui/acceptance_test.go
+++ b/internal/tui/acceptance_test.go
@@ -33,12 +33,15 @@ func TestUAT_Navigation_NumberKeys_SwitchViews(t *testing.T) {
 		name     string
 	}{
 		{'1', ViewTypeJournal, "Journal"},
-		{'2', ViewTypeHabits, "Habits"},
-		{'3', ViewTypeLists, "Lists"},
-		{'4', ViewTypeSearch, "Search"},
-		{'5', ViewTypeStats, "Stats"},
-		{'6', ViewTypeGoals, "Goals"},
-		{'7', ViewTypeSettings, "Settings"},
+		{'2', ViewTypeReview, "Review"},
+		{'3', ViewTypePendingTasks, "PendingTasks"},
+		{'4', ViewTypeQuestions, "Questions"},
+		{'5', ViewTypeHabits, "Habits"},
+		{'6', ViewTypeLists, "Lists"},
+		{'7', ViewTypeGoals, "Goals"},
+		{'8', ViewTypeSearch, "Search"},
+		{'9', ViewTypeStats, "Stats"},
+		{'0', ViewTypeSettings, "Settings"},
 	}
 
 	for _, tt := range tests {
@@ -201,9 +204,9 @@ func TestUAT_Navigation_Esc_GoesBackFromNestedView(t *testing.T) {
 	model.currentView = ViewTypeJournal
 	model.viewStack = []ViewType{} // empty stack
 
-	// Navigate to habits (simulates pressing 2)
-	msg2 := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
-	newModel, _ := model.Update(msg2)
+	// Navigate to habits (simulates pressing 5)
+	msg5 := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
+	newModel, _ := model.Update(msg5)
 	m := newModel.(Model)
 
 	if m.currentView != ViewTypeHabits {
@@ -968,8 +971,8 @@ func TestUAT_HabitsView_ShowsHabitDetails(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -1015,7 +1018,7 @@ func TestUAT_HabitsView_DeletedHabitsNotShown(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1048,8 +1051,8 @@ func TestUAT_HabitsView_LogHabitFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view and load (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1112,7 +1115,7 @@ func TestUAT_HabitsView_MonthlyHistoryShown(t *testing.T) {
 	model.height = 24
 	model.habitState.viewMode = HabitViewModeMonth // Monthly view by default per UAT
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1149,7 +1152,7 @@ func TestUAT_HabitsView_Navigation(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1211,7 +1214,7 @@ func TestUAT_ListsView_ShowsAllLists(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1263,7 +1266,7 @@ func TestUAT_ListsView_ShowsAccurateCompletionCounts(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1302,7 +1305,7 @@ func TestUAT_ListsView_DeletedListsNotShown(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1340,7 +1343,7 @@ func TestUAT_ListsView_EnterOpensItems(t *testing.T) {
 	model.height = 24
 
 	// Go to lists view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1369,7 +1372,7 @@ func TestUAT_ListsView_CreateListWithAddKey(t *testing.T) {
 	model.height = 24
 
 	// Navigate to lists view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -1538,7 +1541,7 @@ func TestUAT_ListItemsView_ShowsAllItems(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1585,7 +1588,7 @@ func TestUAT_ListItemsView_ToggleDone(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1653,7 +1656,7 @@ func TestUAT_ListItemsView_AddItem(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1700,7 +1703,7 @@ func TestUAT_ListItemsView_DeleteItem(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1744,7 +1747,7 @@ func TestUAT_ListItemsView_EscapeReturnsToLists(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1787,7 +1790,7 @@ func TestUAT_ListItemsView_EditItem(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1842,7 +1845,7 @@ func TestUAT_ListItemsView_EditItem_PersistsChange(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1918,7 +1921,7 @@ func TestUAT_ListItemsView_MoveItem(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items (Shopping list)
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -1990,12 +1993,12 @@ func TestUAT_SearchView_Accessible(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}}
 	newModel, _ := model.Update(msg)
 	m := newModel.(Model)
 
 	if m.currentView != ViewTypeSearch {
-		t.Errorf("'4' should switch to search view, got %v", m.currentView)
+		t.Errorf("'8' should switch to search view, got %v", m.currentView)
 	}
 }
 
@@ -2034,12 +2037,12 @@ func TestUAT_StatsView_Accessible(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}}
 	newModel, _ := model.Update(msg)
 	m := newModel.(Model)
 
 	if m.currentView != ViewTypeStats {
-		t.Errorf("'5' should switch to stats view, got %v", m.currentView)
+		t.Errorf("'9' should switch to stats view, got %v", m.currentView)
 	}
 }
 
@@ -2094,12 +2097,12 @@ func TestUAT_SettingsView_Accessible(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}}
 	newModel, _ := model.Update(msg)
 	m := newModel.(Model)
 
 	if m.currentView != ViewTypeSettings {
-		t.Errorf("'7' should switch to settings view, got %v", m.currentView)
+		t.Errorf("'0' should switch to settings view, got %v", m.currentView)
 	}
 }
 
@@ -2221,8 +2224,8 @@ func TestUAT_DataAccuracy_DeletedItemsNeverAppear(t *testing.T) {
 		t.Error("deleted entry should not appear in journal")
 	}
 
-	// Check habits
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Check habits (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd = model.Update(msg)
 	model = newModel.(Model)
 	loadMsg = cmd()
@@ -2234,8 +2237,8 @@ func TestUAT_DataAccuracy_DeletedItemsNeverAppear(t *testing.T) {
 		t.Error("deleted habit should not appear in habits view")
 	}
 
-	// Check lists
-	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	// Check lists (key 6)
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd = model.Update(msg)
 	model = newModel.(Model)
 	loadMsg = cmd()
@@ -2286,7 +2289,7 @@ func TestUAT_DataAccuracy_CountsAreAccurate(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -2322,7 +2325,7 @@ func TestUAT_DataAccuracy_ChangesAppearImmediately(t *testing.T) {
 	model.height = 24
 
 	// Navigate to list items
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()
@@ -2831,8 +2834,8 @@ func TestUAT_HabitsView_ShowsWeeklyProgress(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -2873,8 +2876,8 @@ func TestUAT_HabitsView_ShowsMonthlyProgress(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -2912,8 +2915,8 @@ func TestUAT_HabitsView_HidesProgressWhenNoGoalsSet(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -2951,8 +2954,8 @@ func TestUAT_HabitsView_MatchesCLIStyle(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3003,8 +3006,8 @@ func TestUAT_HabitsView_DayNavigation(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3062,8 +3065,8 @@ func TestUAT_HabitsView_LogOnSelectedDay(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3130,8 +3133,8 @@ func TestUAT_HabitsView_DeleteHabitFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3196,8 +3199,8 @@ func TestUAT_HabitsView_AddHabitFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3278,12 +3281,12 @@ func TestUAT_GoalsView_Accessible(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, _ := model.Update(msg)
 	m := newModel.(Model)
 
 	if m.currentView != ViewTypeGoals {
-		t.Errorf("'6' should switch to goals view, got %v", m.currentView)
+		t.Errorf("'7' should switch to goals view, got %v", m.currentView)
 	}
 }
 
@@ -3327,8 +3330,8 @@ func TestUAT_GoalsView_ShowsGoalContent(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3384,8 +3387,8 @@ func TestUAT_GoalsView_NavigationUpDown(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3435,8 +3438,8 @@ func TestUAT_GoalsView_ToggleDoneWithSpace(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3493,8 +3496,8 @@ func TestUAT_GoalsView_ShowsDoneStatus(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3528,8 +3531,8 @@ func TestUAT_GoalsView_ShowsGoalID(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3610,8 +3613,8 @@ func TestUAT_GoalsView_MonthNavigation_PreviousMonth(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3666,8 +3669,8 @@ func TestUAT_GoalsView_MonthNavigation_NextMonth(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view and load (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	if cmd != nil {
@@ -3707,8 +3710,8 @@ func TestUAT_GoalsView_AddGoalFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3792,8 +3795,8 @@ func TestUAT_GoalsView_EditGoalFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3873,8 +3876,8 @@ func TestUAT_GoalsView_DeleteGoalFromTUI(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3948,8 +3951,8 @@ func TestUAT_GoalsView_MoveGoalToMonth(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -3964,14 +3967,14 @@ func TestUAT_GoalsView_MoveGoalToMonth(t *testing.T) {
 		t.Fatalf("expected 1 goal, got %d", len(model.goalState.goals))
 	}
 
-	// Press 'm' to move
-	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}}
+	// Press '>' to move (migrate key)
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'>'}}
 	newModel, _ = model.Update(msg)
 	model = newModel.(Model)
 
 	// Should be in move goal mode
 	if !model.moveGoalMode.active {
-		t.Fatal("pressing 'm' should activate move goal mode")
+		t.Fatal("pressing '>' should activate move goal mode")
 	}
 
 	// Type target month (next month)
@@ -4041,8 +4044,8 @@ func TestUAT_GoalsView_ShowsMonthInHeader(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to goals view
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}}
+	// Switch to goals view (key 7)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 
@@ -4783,8 +4786,8 @@ func TestUAT_HabitsView_BackspaceRemovesOccurrence(t *testing.T) {
 	model.width = 80
 	model.height = 24
 
-	// Switch to habits view and load
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
+	// Switch to habits view and load (key 5)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}}
 	newModel, cmd := model.Update(msg)
 	model = newModel.(Model)
 	loadMsg := cmd()

--- a/internal/tui/command.go
+++ b/internal/tui/command.go
@@ -98,20 +98,6 @@ func DefaultCommands() *CommandRegistry {
 	})
 
 	registry.Register(Command{
-		Name:        "Toggle Day/Week View",
-		Description: "Switch between day and week view",
-		Keybinding:  "w",
-		Action: func(m Model) (Model, tea.Cmd) {
-			if m.viewMode == ViewModeDay {
-				m.viewMode = ViewModeWeek
-			} else {
-				m.viewMode = ViewModeDay
-			}
-			return m, m.loadAgendaCmd()
-		},
-	})
-
-	registry.Register(Command{
 		Name:        "Capture",
 		Description: "Open external editor for entry capture",
 		Keybinding:  "c",

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -32,11 +32,14 @@ type KeyMap struct {
 	Back                 key.Binding
 	Help                 key.Binding
 	ViewJournal          key.Binding
+	ViewReview           key.Binding
+	ViewPendingTasks     key.Binding
+	ViewQuestions        key.Binding
 	ViewHabits           key.Binding
 	ViewLists            key.Binding
+	ViewGoals            key.Binding
 	ViewSearch           key.Binding
 	ViewStats            key.Binding
-	ViewGoals            key.Binding
 	ViewSettings         key.Binding
 	CommandPalette       key.Binding
 	LogHabit             key.Binding
@@ -51,6 +54,7 @@ type KeyMap struct {
 	ToggleSummary        key.Binding
 	SetLocation          key.Binding
 	ToggleOverdueContext key.Binding
+	GotoToday            key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -104,8 +108,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("r", "add root"),
 		),
 		Migrate: key.NewBinding(
-			key.WithKeys("m"),
-			key.WithHelp("m", "migrate"),
+			key.WithKeys(">"),
+			key.WithHelp(">", "migrate"),
 		),
 		MigrateToGoal: key.NewBinding(
 			key.WithKeys("M"),
@@ -171,29 +175,41 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("1"),
 			key.WithHelp("1", "journal"),
 		),
-		ViewHabits: key.NewBinding(
+		ViewReview: key.NewBinding(
 			key.WithKeys("2"),
-			key.WithHelp("2", "habits"),
+			key.WithHelp("2", "review"),
+		),
+		ViewPendingTasks: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("3", "pending"),
+		),
+		ViewQuestions: key.NewBinding(
+			key.WithKeys("4"),
+			key.WithHelp("4", "questions"),
+		),
+		ViewHabits: key.NewBinding(
+			key.WithKeys("5"),
+			key.WithHelp("5", "habits"),
 		),
 		ViewLists: key.NewBinding(
-			key.WithKeys("3"),
-			key.WithHelp("3", "lists"),
-		),
-		ViewSearch: key.NewBinding(
-			key.WithKeys("4"),
-			key.WithHelp("4", "search"),
-		),
-		ViewStats: key.NewBinding(
-			key.WithKeys("5"),
-			key.WithHelp("5", "stats"),
+			key.WithKeys("6"),
+			key.WithHelp("6", "lists"),
 		),
 		ViewGoals: key.NewBinding(
-			key.WithKeys("6"),
-			key.WithHelp("6", "goals"),
+			key.WithKeys("7"),
+			key.WithHelp("7", "goals"),
+		),
+		ViewSearch: key.NewBinding(
+			key.WithKeys("8"),
+			key.WithHelp("8", "search"),
+		),
+		ViewStats: key.NewBinding(
+			key.WithKeys("9"),
+			key.WithHelp("9", "stats"),
 		),
 		ViewSettings: key.NewBinding(
-			key.WithKeys("7"),
-			key.WithHelp("7", "settings"),
+			key.WithKeys("0"),
+			key.WithHelp("0", "settings"),
 		),
 		CommandPalette: key.NewBinding(
 			key.WithKeys("ctrl+p", ":"),
@@ -247,6 +263,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("C"),
 			key.WithHelp("C", "toggle context"),
 		),
+		GotoToday: key.NewBinding(
+			key.WithKeys("T"),
+			key.WithHelp("T", "go to today"),
+		),
 	}
 }
 
@@ -257,7 +277,8 @@ func (k KeyMap) ShortHelp() []key.Binding {
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Top, k.Bottom},
-		{k.Done, k.CancelEntry, k.Edit, k.Add, k.AddChild, k.AddRoot, k.Migrate, k.Priority, k.Capture, k.Delete},
-		{k.ToggleView, k.GotoDate, k.Quit, k.Help},
+		{k.Done, k.CancelEntry, k.UncancelEntry, k.Edit, k.Add, k.AddChild, k.AddRoot, k.Delete},
+		{k.Migrate, k.MoveToList, k.Retype, k.Priority, k.Answer, k.Capture, k.Undo},
+		{k.ToggleView, k.GotoDate, k.GotoToday, k.Quit, k.Help},
 	}
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -144,6 +144,14 @@ type searchResultsMsg struct {
 	query   string
 }
 
+type pendingTasksLoadedMsg struct {
+	entries []domain.Entry
+}
+
+type questionsLoadedMsg struct {
+	entries []domain.Entry
+}
+
 type statsLoadedMsg struct {
 	stats *domain.Stats
 }


### PR DESCRIPTION
## Summary

- **Issue #67**: Separate Journal (day) and Review (week) views
  - Journal view (key `1`) always shows day mode
  - Review view (key `2`) always shows week mode
  - Removed `w` toggle between day/week modes
  - `h/l` navigation moves by days in Journal, weeks in Review

- **Issue #68**: Entry type change with `t` key (verified working)

- **Issue #70**: Move to list with `L` key (verified working)

- **Issue #71**: Changed migrate shortcut from `m` to `>`

- Added `T` key to jump to today in Journal/Review views

- Added Pending Tasks (key `3`) and Questions (key `4`) views
  - Reordered view keys: 1-Journal, 2-Review, 3-Pending, 4-Questions, 5-Habits, 6-Lists, 7-Goals, 8-Search, 9-Stats, 0-Settings

## Test plan

- [x] All TUI tests pass
- [x] Verify `1` key opens Journal view in day mode
- [x] Verify `2` key opens Review view in week mode
- [x] Verify `h/l` moves by days in Journal, weeks in Review
- [x] Verify `T` key jumps to today
- [x] Verify `>` key triggers migration
- [x] Verify `t` key changes entry type
- [x] Verify `L` key moves entry to list

Fixes #67, #68, #70, #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)