### PR TITLE
fix: Dynamic empty message and remove overdue section (#84, #85)

### DIFF
--- a/internal/tui/acceptance_test.go
+++ b/internal/tui/acceptance_test.go
@@ -1433,8 +1433,9 @@ func TestUAT_JournalView_MoveEntryToList(t *testing.T) {
 	bujoSvc, habitSvc, listSvc, _ := setupTestServices(t)
 	ctx := context.Background()
 
-	// Create a journal entry
-	entries, err := bujoSvc.LogEntries(ctx, ". Task to move", service.LogEntriesOptions{})
+	// Create a journal entry for today
+	opts := service.LogEntriesOptions{Date: time.Now()}
+	entries, err := bujoSvc.LogEntries(ctx, ". Task to move", opts)
 	if err != nil {
 		t.Fatalf("failed to create entry: %v", err)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1111,14 +1111,8 @@ func (m Model) flattenAgenda(agenda *service.MultiDayAgenda) []EntryItem {
 
 	now := time.Now()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	viewDateNormalized := time.Date(m.viewDate.Year(), m.viewDate.Month(), m.viewDate.Day(), 0, 0, 0, 0, m.viewDate.Location())
-	isViewingPast := viewDateNormalized.Before(today)
 
 	var items []EntryItem
-
-	if len(agenda.Overdue) > 0 && !isViewingPast {
-		items = append(items, m.flattenEntries(agenda.Overdue, "⚠️  OVERDUE", true, today)...)
-	}
 
 	for _, day := range agenda.Days {
 		if len(day.Entries) == 0 {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -168,7 +168,11 @@ func (m Model) renderJournalContent() string {
 	}
 
 	if len(m.entries) == 0 {
-		sb.WriteString(HelpStyle.Render("No entries for the last 7 days."))
+		emptyMsg := "No entries for today."
+		if m.viewMode == ViewModeWeek {
+			emptyMsg = "No entries for the last 7 days."
+		}
+		sb.WriteString(HelpStyle.Render(emptyMsg))
 		sb.WriteString("\n\n")
 	} else {
 		availableLines := m.height - 6 // 2 for toolbar, 2 for help, 2 for padding


### PR DESCRIPTION
## Summary
- Empty journal message now dynamically reflects view mode: "No entries for today" in day view vs "No entries for the last 7 days" in week view (fixes #84)
- Removed overdue section from journal/review views - this functionality has been superseded by the dedicated Outstanding Tasks view (fixes #85)
- Cleaned up obsolete overdue-related tests and fixed acceptance test that relied on removed behavior

🤖 Generated with [Claude Code](https://claude.ai/code)