### PR TITLE
fix: Make list item circle clickable for completion (#87)

### DIFF
--- a/docs/issues.txt
+++ b/docs/issues.txt
@@ -84,6 +84,6 @@ x the descriptions in the sidebar of the frontend are not very good, suggest bet
 x TUI - "No entries for the last 7 days" message should reflect the actual view being displayed, not hardcoded to 7 days
 x TUI - overdue tasks still appearing in journal and review views
 x FE - migrate entry from pending tasks is not doing anything
-. Lists - click on circle should complete list item. Don't need the tick next to it
+x Lists - click on circle should complete list item. Don't need the tick next to it
 . Need to password protect app / database - encrypt data at rest
 . Double click on entry in search should take me to the entry in the review view

--- a/frontend/src/components/bujo/ListsView.test.tsx
+++ b/frontend/src/components/bujo/ListsView.test.tsx
@@ -551,46 +551,12 @@ describe('ListsView - Uncancel List Item', () => {
   })
 })
 
-describe('ListsView - Click and Tick/Untick Behavior', () => {
+describe('ListsView - Circle Click to Toggle Completion', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('clicking on a task item does not call toggle handler', async () => {
-    const user = userEvent.setup()
-    const { MarkListItemDone, MarkListItemUndone } = await import('@/wailsjs/go/wails/App')
-    render(<ListsView lists={[createTestList({
-      name: 'Shopping',
-      items: [createTestItem({ id: 42, content: 'Buy milk', type: 'task', done: false })]
-    })]} />)
-
-    // Click on the item row
-    await user.click(screen.getByText('Buy milk'))
-
-    // Neither mark done nor mark undone should be called
-    expect(MarkListItemDone).not.toHaveBeenCalled()
-    expect(MarkListItemUndone).not.toHaveBeenCalled()
-  })
-
-  it('shows tick button on task items to mark as done', () => {
-    render(<ListsView lists={[createTestList({
-      name: 'Shopping',
-      items: [createTestItem({ content: 'Buy milk', type: 'task', done: false })]
-    })]} />)
-
-    expect(screen.getByTitle('Mark as done')).toBeInTheDocument()
-  })
-
-  it('shows untick button on done items to mark as not done', () => {
-    render(<ListsView lists={[createTestList({
-      name: 'Shopping',
-      items: [createTestItem({ content: 'Buy milk', type: 'done', done: true })]
-    })]} />)
-
-    expect(screen.getByTitle('Mark as not done')).toBeInTheDocument()
-  })
-
-  it('calls MarkListItemDone when tick button is clicked', async () => {
+  it('clicking on task circle calls MarkListItemDone', async () => {
     const user = userEvent.setup()
     const { MarkListItemDone } = await import('@/wailsjs/go/wails/App')
     const onListChanged = vi.fn()
@@ -606,7 +572,7 @@ describe('ListsView - Click and Tick/Untick Behavior', () => {
     })
   })
 
-  it('calls MarkListItemUndone when untick button is clicked', async () => {
+  it('clicking on done circle calls MarkListItemUndone', async () => {
     const user = userEvent.setup()
     const { MarkListItemUndone } = await import('@/wailsjs/go/wails/App')
     const onListChanged = vi.fn()
@@ -622,7 +588,32 @@ describe('ListsView - Click and Tick/Untick Behavior', () => {
     })
   })
 
-  it('does not show tick/untick button on cancelled items', () => {
+  it('clicking on item text does not call toggle handler', async () => {
+    const user = userEvent.setup()
+    const { MarkListItemDone, MarkListItemUndone } = await import('@/wailsjs/go/wails/App')
+    render(<ListsView lists={[createTestList({
+      name: 'Shopping',
+      items: [createTestItem({ id: 42, content: 'Buy milk', type: 'task', done: false })]
+    })]} />)
+
+    await user.click(screen.getByText('Buy milk'))
+
+    expect(MarkListItemDone).not.toHaveBeenCalled()
+    expect(MarkListItemUndone).not.toHaveBeenCalled()
+  })
+
+  it('does not show separate tick button (circle is the toggle)', () => {
+    render(<ListsView lists={[createTestList({
+      name: 'Shopping',
+      items: [createTestItem({ content: 'Buy milk', type: 'task', done: false })]
+    })]} />)
+
+    // The circle itself should be the "Mark as done" button, no separate tick icon
+    const markDoneButtons = screen.getAllByTitle('Mark as done')
+    expect(markDoneButtons).toHaveLength(1) // Only the circle, no separate tick
+  })
+
+  it('cancelled items circle is not clickable', () => {
     render(<ListsView lists={[createTestList({
       name: 'Shopping',
       items: [createTestItem({ content: 'Buy milk', type: 'cancelled' })]
@@ -630,15 +621,6 @@ describe('ListsView - Click and Tick/Untick Behavior', () => {
 
     expect(screen.queryByTitle('Mark as done')).not.toBeInTheDocument()
     expect(screen.queryByTitle('Mark as not done')).not.toBeInTheDocument()
-  })
-
-  it('shows task bullet symbol in mark as not done button', () => {
-    render(<ListsView lists={[createTestList({
-      name: 'Shopping',
-      items: [createTestItem({ id: 42, content: 'Buy milk', type: 'done' })]
-    })]} />)
-    const undoneButton = screen.getByTitle('Mark as not done')
-    expect(undoneButton).toHaveTextContent('•')
   })
 })
 

--- a/frontend/src/components/bujo/ListsView.tsx
+++ b/frontend/src/components/bujo/ListsView.tsx
@@ -1,6 +1,6 @@
 import { BujoList } from '@/types/bujo'
 import { cn } from '@/lib/utils'
-import { List, CheckCircle2, Circle, ChevronRight, Plus, Trash2, Pencil, X, Ban, RotateCcw, MoveRight, Check } from 'lucide-react'
+import { List, CheckCircle2, Circle, ChevronRight, Plus, Trash2, Pencil, X, Ban, RotateCcw, MoveRight } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
 import { MarkListItemDone, MarkListItemUndone, AddListItem, RemoveListItem, CreateList, DeleteList, RenameList, EditListItem, CancelListItem, UncancelListItem, MoveListItem } from '@/wailsjs/go/wails/App'
 import { ConfirmDialog } from './ConfirmDialog'
@@ -212,29 +212,22 @@ function ListCard({ list, otherLists, isExpanded, onToggle, onToggleItem, onAddI
               className="flex items-center gap-3 py-1.5 group hover:bg-secondary/20 rounded px-2 -mx-2"
             >
               {item.type === 'done' ? (
-                <CheckCircle2 className="w-4 h-4 text-bujo-done flex-shrink-0" />
-              ) : item.type === 'cancelled' ? (
-                <Ban className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-              ) : (
-                <Circle className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-              )}
-              {/* Tick/untick buttons for task and done items */}
-              {item.type === 'task' && (
-                <button
-                  onClick={(e) => handleTickItem(e, item.id, item.done)}
-                  title="Mark as done"
-                  className="p-1 rounded text-muted-foreground hover:text-green-500 hover:bg-green-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <Check className="w-3.5 h-3.5" />
-                </button>
-              )}
-              {item.type === 'done' && (
                 <button
                   onClick={(e) => handleTickItem(e, item.id, item.done)}
                   title="Mark as not done"
-                  className="p-1 rounded text-muted-foreground hover:text-orange-600 hover:bg-orange-500/20 transition-colors opacity-0 group-hover:opacity-100"
+                  className="flex-shrink-0 hover:opacity-70 transition-opacity"
                 >
-                  <span className="text-sm font-bold leading-none">•</span>
+                  <CheckCircle2 className="w-4 h-4 text-bujo-done" />
+                </button>
+              ) : item.type === 'cancelled' ? (
+                <Ban className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              ) : (
+                <button
+                  onClick={(e) => handleTickItem(e, item.id, item.done)}
+                  title="Mark as done"
+                  className="flex-shrink-0 hover:text-green-500 transition-colors text-muted-foreground"
+                >
+                  <Circle className="w-4 h-4" />
                 </button>
               )}
               {editingItemId === item.id ? (


### PR DESCRIPTION
## Summary
- Click circle icon to toggle list item completion
- Removed separate tick button - circle itself is now the toggle
- Simplified UI matches user expectations

## Test plan
- [x] Tests updated and passing (653 tests)
- [x] Build successful
- [ ] Manual: Click circle on task item → marks as done
- [ ] Manual: Click checkmark on done item → marks as not done

🤖 Generated with [Claude Code](https://claude.com/claude-code)