### PR TITLE
fix: Make goal circles clickable for completion toggle (#83)

### DIFF
--- a/docs/issues.txt
+++ b/docs/issues.txt
@@ -80,7 +80,7 @@ x the descriptions in the sidebar of the frontend are not very good, suggest bet
 . Package-level mutable state in history command - var listItemRepo anti-pattern (cmd/bujo/cmd/history.go:14-17)
 . If you cancel or delete and answer to a question, you should be able to answer it again
 . How do you add an answer to a question using the capture modal?
-. You should be able to click on the circle on the goals in the monthly goals to mark it as completed
+x You should be able to click on the circle on the goals in the monthly goals to mark it as completed
 x TUI - "No entries for the last 7 days" message should reflect the actual view being displayed, not hardcoded to 7 days
 x TUI - overdue tasks still appearing in journal and review views
 x FE - migrate entry from pending tasks is not doing anything

--- a/frontend/src/components/bujo/GoalsView.test.tsx
+++ b/frontend/src/components/bujo/GoalsView.test.tsx
@@ -415,10 +415,16 @@ describe('GoalsView - Click and Tick/Untick Behavior', () => {
     expect(screen.queryByTitle('Mark as not done')).not.toBeInTheDocument()
   })
 
-  it('shows task bullet symbol in mark as not done button', () => {
-    render(<GoalsView goals={[createTestGoal({ content: 'Done Goal', status: 'done' })]} />)
-    const undoneButton = screen.getByTitle('Mark as not done')
-    expect(undoneButton).toHaveTextContent('•')
+  it('clicking circle on done goal marks as not done', async () => {
+    const user = userEvent.setup()
+    const onGoalChanged = vi.fn()
+    render(<GoalsView goals={[createTestGoal({ id: 42, content: 'Done Goal', status: 'done' })]} onGoalChanged={onGoalChanged} />)
+
+    await user.click(screen.getByTitle('Mark as not done'))
+
+    await waitFor(() => {
+      expect(MarkGoalActive).toHaveBeenCalledWith(42)
+    })
   })
 })
 

--- a/frontend/src/components/bujo/GoalsView.tsx
+++ b/frontend/src/components/bujo/GoalsView.tsx
@@ -1,6 +1,6 @@
 import { Goal } from '@/types/bujo';
 import { cn } from '@/lib/utils';
-import { Target, CheckCircle2, Circle, ChevronLeft, ChevronRight, Plus, X, Trash2, ArrowRight, Pencil, Ban, Undo2, Check } from 'lucide-react';
+import { Target, CheckCircle2, Circle, ChevronLeft, ChevronRight, Plus, X, Trash2, ArrowRight, Pencil, Ban, Undo2 } from 'lucide-react';
 import { format, parse, addMonths } from 'date-fns';
 import { useState, useRef } from 'react';
 import { MarkGoalDone, MarkGoalActive, CreateGoal, DeleteGoal, MigrateGoal, UpdateGoal, CancelGoal, UncancelGoal } from '@/wailsjs/go/wails/App';
@@ -261,11 +261,25 @@ export function GoalsView({ goals: initialGoals, onGoalChanged, onError }: Goals
               )}
             >
               {goal.status === 'done' ? (
-                <CheckCircle2 className="w-5 h-5 text-bujo-done flex-shrink-0" />
+                <button
+                  onClick={() => handleToggleGoal(goal)}
+                  title="Mark as not done"
+                  className="flex-shrink-0 hover:opacity-70 transition-opacity"
+                >
+                  <CheckCircle2 className="w-5 h-5 text-bujo-done" />
+                </button>
               ) : goal.status === 'migrated' ? (
                 <ArrowRight className="w-5 h-5 text-muted-foreground flex-shrink-0" />
+              ) : goal.status === 'cancelled' ? (
+                <Ban className="w-5 h-5 text-muted-foreground flex-shrink-0" />
               ) : (
-                <Circle className="w-5 h-5 text-muted-foreground flex-shrink-0" />
+                <button
+                  onClick={() => handleToggleGoal(goal)}
+                  title="Mark as done"
+                  className="flex-shrink-0 hover:text-green-500 transition-colors text-muted-foreground"
+                >
+                  <Circle className="w-5 h-5" />
+                </button>
               )}
               {editingGoal?.id === goal.id ? (
                 <input
@@ -291,25 +305,6 @@ export function GoalsView({ goals: initialGoals, onGoalChanged, onError }: Goals
                     </span>
                   )}
                 </span>
-              )}
-              {/* Tick/untick buttons for active and done goals */}
-              {goal.status === 'active' && (
-                <button
-                  onClick={() => handleToggleGoal(goal)}
-                  title="Mark as done"
-                  className="p-1 rounded text-muted-foreground hover:text-green-500 hover:bg-green-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <Check className="w-4 h-4" />
-                </button>
-              )}
-              {goal.status === 'done' && (
-                <button
-                  onClick={() => handleToggleGoal(goal)}
-                  title="Mark as not done"
-                  className="p-1 rounded text-muted-foreground hover:text-orange-600 hover:bg-orange-500/20 transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <span className="text-sm font-bold leading-none">•</span>
-                </button>
               )}
               {goal.status !== 'migrated' && (
                 <button


### PR DESCRIPTION
## Summary
- Circle icons on goals are now clickable buttons for toggling completion status
- Clicking a done goal (CheckCircle2) marks it as not done; clicking an active goal (Circle) marks it as done
- Removed redundant tick/untick buttons - the circle itself handles completion now

🤖 Generated with [Claude Code](https://claude.com/claude-code)