### PR TITLE
feat: Double-click search result navigates to review view (#89)

### DIFF
--- a/docs/issues.txt
+++ b/docs/issues.txt
@@ -86,4 +86,4 @@ x TUI - overdue tasks still appearing in journal and review views
 x FE - migrate entry from pending tasks is not doing anything
 x Lists - click on circle should complete list item. Don't need the tick next to it
 . Need to password protect app / database - encrypt data at rest
-. Double click on entry in search should take me to the entry in the review view
+x Double click on entry in search should take me to the entry in the review view

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -414,6 +414,12 @@ function App() {
     })
   }, [])
 
+  const handleSearchNavigate = useCallback((result: SearchResult) => {
+    const entryDate = new Date(result.date)
+    setReviewAnchorDate(startOfDay(entryDate))
+    setView('week')
+  }, [])
+
   const viewTitles: Record<ViewType, string> = {
     today: 'Journal',
     week: 'Weekly Review',
@@ -637,7 +643,7 @@ function App() {
 
           {view === 'search' && (
             <div className="max-w-3xl mx-auto">
-              <SearchView onMigrate={handleSearchMigrate} />
+              <SearchView onMigrate={handleSearchMigrate} onNavigateToEntry={handleSearchNavigate} />
             </div>
           )}
 

--- a/frontend/src/components/bujo/SearchView.test.tsx
+++ b/frontend/src/components/bujo/SearchView.test.tsx
@@ -1114,3 +1114,62 @@ describe('SearchView - Context Pill', () => {
     })
   })
 })
+
+describe('SearchView - Double Click Navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls onNavigateToEntry when double-clicking a search result', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 42, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const onNavigateToEntry = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchView onNavigateToEntry={onNavigateToEntry} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test entry')).toBeInTheDocument()
+    })
+
+    const result = screen.getByText('Test entry').closest('[data-result-id]')
+    expect(result).toBeInTheDocument()
+
+    await user.dblClick(result!)
+
+    expect(onNavigateToEntry).toHaveBeenCalledWith({
+      id: 42,
+      content: 'Test entry',
+      type: 'task',
+      priority: 'none',
+      date: '2024-01-15T10:00:00Z',
+      parentId: null,
+    })
+  })
+
+  it('does not call onNavigateToEntry on single click', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 42, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const onNavigateToEntry = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchView onNavigateToEntry={onNavigateToEntry} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test entry')).toBeInTheDocument()
+    })
+
+    const result = screen.getByText('Test entry').closest('[data-result-id]')
+    await user.click(result!)
+
+    expect(onNavigateToEntry).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/bujo/SearchView.tsx
+++ b/frontend/src/components/bujo/SearchView.tsx
@@ -28,9 +28,10 @@ interface AncestorEntry {
 
 interface SearchViewProps {
   onMigrate?: (entry: SearchResult) => void;
+  onNavigateToEntry?: (entry: SearchResult) => void;
 }
 
-export function SearchView({ onMigrate }: SearchViewProps) {
+export function SearchView({ onMigrate, onNavigateToEntry }: SearchViewProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
@@ -387,6 +388,7 @@ export function SearchView({ onMigrate }: SearchViewProps) {
             <div
               key={result.id}
               onClick={() => toggleExpanded(result)}
+              onDoubleClick={() => onNavigateToEntry?.(result)}
               className={cn(
                 'p-3 rounded-lg border border-border cursor-pointer',
                 'bg-card transition-colors group',


### PR DESCRIPTION
## Summary
- Add `onNavigateToEntry` callback prop to SearchView component
- Implement double-click handler on search results that triggers navigation
- Wire up navigation in App.tsx to switch to Review view with entry's date as anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)