### PR TITLE
fix: Move SQL bypass from BackupService to repository layer

### DIFF
--- a/internal/repository/sqlite/backup_repository.go
+++ b/internal/repository/sqlite/backup_repository.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
 )
 
 type BackupRepository struct {
@@ -16,4 +18,28 @@ func NewBackupRepository(db *sql.DB) *BackupRepository {
 func (r *BackupRepository) Backup(ctx context.Context, destPath string) error {
 	_, err := r.db.ExecContext(ctx, "VACUUM INTO ?", destPath)
 	return err
+}
+
+func (r *BackupRepository) VerifyIntegrity(ctx context.Context, backupPath string) error {
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		return fmt.Errorf("backup file does not exist: %s", backupPath)
+	}
+
+	db, err := sql.Open("sqlite", backupPath)
+	if err != nil {
+		return fmt.Errorf("failed to open backup: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var result string
+	err = db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&result)
+	if err != nil {
+		return fmt.Errorf("failed to verify backup: %w", err)
+	}
+
+	if result != "ok" {
+		return fmt.Errorf("backup integrity check failed: %s", result)
+	}
+
+	return nil
 }

--- a/internal/repository/sqlite/backup_repository_test.go
+++ b/internal/repository/sqlite/backup_repository_test.go
@@ -1,0 +1,61 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupRepository_VerifyIntegrity_ValidBackup_ReturnsNil(t *testing.T) {
+	db, err := OpenAndMigrate(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tempDir := t.TempDir()
+	backupPath := filepath.Join(tempDir, "test-backup.db")
+
+	repo := NewBackupRepository(db)
+	ctx := context.Background()
+
+	err = repo.Backup(ctx, backupPath)
+	require.NoError(t, err)
+
+	err = repo.VerifyIntegrity(ctx, backupPath)
+
+	assert.NoError(t, err)
+}
+
+func TestBackupRepository_VerifyIntegrity_CorruptFile_ReturnsError(t *testing.T) {
+	db, err := OpenAndMigrate(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tempDir := t.TempDir()
+	corruptPath := filepath.Join(tempDir, "corrupt.db")
+	err = os.WriteFile(corruptPath, []byte("not a valid sqlite file"), 0644)
+	require.NoError(t, err)
+
+	repo := NewBackupRepository(db)
+	ctx := context.Background()
+
+	err = repo.VerifyIntegrity(ctx, corruptPath)
+
+	assert.Error(t, err)
+}
+
+func TestBackupRepository_VerifyIntegrity_MissingFile_ReturnsError(t *testing.T) {
+	db, err := OpenAndMigrate(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewBackupRepository(db)
+	ctx := context.Background()
+
+	err = repo.VerifyIntegrity(ctx, "/nonexistent/path.db")
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Move direct `sql.Open()` call from `BackupService.VerifyBackup()` to repository layer
- Add `VerifyIntegrity()` method to `BackupRepository` interface
- Add repository-level tests for the new method

## Background
`BackupService.VerifyBackup()` was directly calling `sql.Open("sqlite", backupPath)` instead of using the repository interface. This violated hexagonal architecture principles where the service layer should depend only on interfaces, not concrete implementations.

## Changes
| File | Change |
|------|--------|
| `internal/service/backup.go` | Added `VerifyIntegrity` to interface, simplified `VerifyBackup()` to delegate to repository |
| `internal/repository/sqlite/backup_repository.go` | Implemented `VerifyIntegrity()` with SQLite integrity check |
| `internal/repository/sqlite/backup_repository_test.go` | New test file with 3 tests |

## Test plan
- [x] All existing backup service tests pass
- [x] New repository tests for `VerifyIntegrity` pass
- [x] Full test suite passes
- [x] `go vet` clean

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)