### PR TITLE
refactor: Centralize CLI service initialization (#77)

### DIFF
--- a/cmd/bujo/cmd/archive.go
+++ b/cmd/bujo/cmd/archive.go
@@ -6,12 +6,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/typingincolor/bujo/internal/repository/sqlite"
-	"github.com/typingincolor/bujo/internal/service"
 )
 
 var (
-	archiveService   *service.ArchiveService
 	archiveOlderThan string
 	archiveExecute   bool
 )
@@ -25,14 +22,6 @@ By default, shows how many records would be archived (dry run).
 Use --execute to actually perform the archive operation.
 
 Old versions are rows with valid_to set, meaning they've been superseded.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
-			return err
-		}
-		listItemRepo := sqlite.NewListItemRepository(db)
-		archiveService = service.NewArchiveService(listItemRepo)
-		return nil
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cutoff, err := parseArchiveCutoff(archiveOlderThan)
 		if err != nil {

--- a/cmd/bujo/cmd/backup.go
+++ b/cmd/bujo/cmd/backup.go
@@ -7,11 +7,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	sqliterepo "github.com/typingincolor/bujo/internal/repository/sqlite"
-	"github.com/typingincolor/bujo/internal/service"
 )
 
-var backupService *service.BackupService
 var backupDir string
 
 func getDefaultBackupDir() string {
@@ -35,8 +32,6 @@ Backups are stored in ~/.bujo/backups/ by default.`,
 			return err
 		}
 		backupDir = getDefaultBackupDir()
-		backupRepo := sqliterepo.NewBackupRepository(db)
-		backupService = service.NewBackupService(backupRepo)
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bujo/cmd/export.go
+++ b/cmd/bujo/cmd/export.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/typingincolor/bujo/internal/domain"
-	"github.com/typingincolor/bujo/internal/repository/sqlite"
-	"github.com/typingincolor/bujo/internal/service"
 )
 
 var exportCmd = &cobra.Command{
@@ -47,20 +45,6 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return runMarkdownExport(cmd, args[0])
 	}
 
-	entryRepo := sqlite.NewEntryRepository(db)
-	habitRepo := sqlite.NewHabitRepository(db)
-	habitLogRepo := sqlite.NewHabitLogRepository(db)
-	dayContextRepo := sqlite.NewDayContextRepository(db)
-	summaryRepo := sqlite.NewSummaryRepository(db)
-	listRepo := sqlite.NewListRepository(db)
-	listItemRepo := sqlite.NewListItemRepository(db)
-	goalRepo := sqlite.NewGoalRepository(db)
-
-	exportSvc := service.NewExportService(
-		entryRepo, habitRepo, habitLogRepo, dayContextRepo,
-		summaryRepo, listRepo, listItemRepo, goalRepo,
-	)
-
 	opts := domain.NewExportOptions()
 
 	if exportFrom != "" {
@@ -78,7 +62,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		opts = opts.WithDateRange(from, to)
 	}
 
-	data, err := exportSvc.Export(cmd.Context(), opts)
+	data, err := exportService.Export(cmd.Context(), opts)
 	if err != nil {
 		return fmt.Errorf("export failed: %w", err)
 	}

--- a/cmd/bujo/cmd/history.go
+++ b/cmd/bujo/cmd/history.go
@@ -7,13 +7,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/typingincolor/bujo/internal/domain"
-	"github.com/typingincolor/bujo/internal/repository/sqlite"
-	"github.com/typingincolor/bujo/internal/service"
-)
-
-var (
-	historyService *service.HistoryService
-	listItemRepo   *sqlite.ListItemRepository
 )
 
 var historyCmd = &cobra.Command{
@@ -23,14 +16,6 @@ var historyCmd = &cobra.Command{
 
 The event sourcing system keeps track of all changes to list items,
 allowing you to see previous versions and restore them if needed.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
-			return err
-		}
-		listItemRepo = sqlite.NewListItemRepository(db)
-		historyService = service.NewHistoryService(listItemRepo)
-		return nil
-	},
 }
 
 var historyShowCmd = &cobra.Command{

--- a/cmd/bujo/cmd/import.go
+++ b/cmd/bujo/cmd/import.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/typingincolor/bujo/internal/domain"
-	"github.com/typingincolor/bujo/internal/repository/sqlite"
-	"github.com/typingincolor/bujo/internal/service"
 )
 
 var importCmd = &cobra.Command{
@@ -58,23 +56,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, "Warning: Replace mode will delete all existing data!")
 	}
 
-	entryRepo := sqlite.NewEntryRepository(db)
-	habitRepo := sqlite.NewHabitRepository(db)
-	habitLogRepo := sqlite.NewHabitLogRepository(db)
-	dayContextRepo := sqlite.NewDayContextRepository(db)
-	summaryRepo := sqlite.NewSummaryRepository(db)
-	listRepo := sqlite.NewListRepository(db)
-	listItemRepo := sqlite.NewListItemRepository(db)
-	goalRepo := sqlite.NewGoalRepository(db)
-
-	importSvc := service.NewImportService(
-		entryRepo, habitRepo, habitLogRepo, dayContextRepo,
-		summaryRepo, listRepo, listItemRepo, goalRepo,
-	)
-
 	opts := domain.NewImportOptions(mode)
 
-	if err := importSvc.Import(cmd.Context(), &data, opts); err != nil {
+	if err := importService.Import(cmd.Context(), &data, opts); err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Centralizes service initialization in `root.go` for archive, backup, export, import, and history commands
- Removes direct SQLite repository instantiation from individual command files
- Eliminates package-level `listItemRepo` variable from history.go (also addresses issue #80)

## Test plan

- [x] All existing tests pass
- [x] `go vet` shows no issues
- [x] `golangci-lint` passes
- [ ] Manual verification: `bujo archive`, `bujo backup`, `bujo export`, `bujo import`, `bujo history` commands work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)