### PR TITLE
feat: Click entry symbol to toggle task done state

### DIFF
--- a/frontend/src/components/bujo/EntryItem.test.tsx
+++ b/frontend/src/components/bujo/EntryItem.test.tsx
@@ -376,7 +376,7 @@ describe('EntryItem', () => {
       expect(screen.getByTitle('Mark as not done')).toBeInTheDocument()
     })
 
-    it('shows task bullet symbol in untick button', () => {
+    it('shows checkmark symbol in untick button for done entries', () => {
       render(
         <EntryItem
           entry={createTestEntry({ type: 'done' })}
@@ -384,7 +384,7 @@ describe('EntryItem', () => {
         />
       )
       const untickButton = screen.getByTitle('Mark as not done')
-      expect(untickButton).toHaveTextContent('•')
+      expect(untickButton).toHaveTextContent('✓')
     })
 
     it('calls onToggleDone when tick button is clicked', () => {
@@ -704,6 +704,88 @@ describe('EntryItem', () => {
       fireEvent.contextMenu(container)
 
       expect(screen.getByRole('menuitem', { name: 'Cycle priority' })).toBeInTheDocument()
+    })
+  })
+
+  describe('symbol click toggle', () => {
+    it('calls onToggleDone when clicking symbol for task entry', () => {
+      const onToggleDone = vi.fn()
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'task' })}
+          onToggleDone={onToggleDone}
+        />
+      )
+
+      const symbolButton = screen.getByTitle('Mark as done')
+      fireEvent.click(symbolButton)
+      expect(onToggleDone).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onToggleDone when clicking symbol for done entry', () => {
+      const onToggleDone = vi.fn()
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'done' })}
+          onToggleDone={onToggleDone}
+        />
+      )
+
+      const symbolButton = screen.getByTitle('Mark as not done')
+      fireEvent.click(symbolButton)
+      expect(onToggleDone).toHaveBeenCalledTimes(1)
+    })
+
+    it('symbol is not clickable for note entry', () => {
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'note' })}
+          onToggleDone={() => {}}
+        />
+      )
+
+      // Note entries should not have a clickable symbol
+      expect(screen.queryByTitle('Mark as done')).not.toBeInTheDocument()
+      expect(screen.queryByTitle('Mark as not done')).not.toBeInTheDocument()
+    })
+
+    it('symbol click does not trigger row onSelect', () => {
+      const onToggleDone = vi.fn()
+      const onSelect = vi.fn()
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'task' })}
+          onToggleDone={onToggleDone}
+          onSelect={onSelect}
+        />
+      )
+
+      const symbolButton = screen.getByTitle('Mark as done')
+      fireEvent.click(symbolButton)
+      expect(onToggleDone).toHaveBeenCalledTimes(1)
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('symbol shows task bullet for task entries', () => {
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'task' })}
+          onToggleDone={() => {}}
+        />
+      )
+      const symbolButton = screen.getByTitle('Mark as done')
+      expect(symbolButton).toHaveTextContent('•')
+    })
+
+    it('symbol shows checkmark for done entries', () => {
+      render(
+        <EntryItem
+          entry={createTestEntry({ type: 'done' })}
+          onToggleDone={() => {}}
+        />
+      )
+      const symbolButton = screen.getByTitle('Mark as not done')
+      expect(symbolButton).toHaveTextContent('✓')
     })
   })
 

--- a/frontend/src/components/bujo/EntryItem.tsx
+++ b/frontend/src/components/bujo/EntryItem.tsx
@@ -3,7 +3,7 @@ import { Entry, EntryType } from '@/types/bujo';
 import { EntrySymbol } from './EntrySymbol';
 import { cn } from '@/lib/utils';
 import { calculateMenuPosition } from '@/lib/menuPosition';
-import { ChevronRight, ChevronDown, Pencil, Trash2, MessageCircle, X, RotateCcw, ArrowRight, Check, Flag, RefreshCw } from 'lucide-react';
+import { ChevronRight, ChevronDown, Pencil, Trash2, MessageCircle, X, RotateCcw, ArrowRight, Flag, RefreshCw } from 'lucide-react';
 
 interface EntryItemProps {
   entry: Entry;
@@ -136,8 +136,21 @@ export function EntryItem({
         <span className="w-4" />
       )}
 
-      {/* Symbol */}
-      <EntrySymbol type={entry.type} priority={entry.priority} />
+      {/* Symbol - clickable for task/done entries */}
+      {isToggleable && onToggleDone ? (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleDone();
+          }}
+          className="cursor-pointer hover:opacity-70 transition-opacity"
+          title={entry.type === 'task' ? 'Mark as done' : 'Mark as not done'}
+        >
+          <EntrySymbol type={entry.type} priority={entry.priority} />
+        </button>
+      ) : (
+        <EntrySymbol type={entry.type} priority={entry.priority} />
+      )}
 
       {/* Content */}
       <span className={cn('flex-1 text-sm', contentStyles[entry.type])}>
@@ -153,30 +166,6 @@ export function EntryItem({
 
       {/* Action buttons (shown on hover) */}
       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        {onToggleDone && entry.type === 'task' && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleDone();
-            }}
-            title="Mark as done"
-            className="p-1 rounded hover:bg-green-500/20 text-muted-foreground hover:text-green-600 transition-colors"
-          >
-            <Check className="w-3.5 h-3.5" />
-          </button>
-        )}
-        {onToggleDone && entry.type === 'done' && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleDone();
-            }}
-            title="Mark as not done"
-            className="p-1 rounded hover:bg-orange-500/20 text-muted-foreground hover:text-orange-600 transition-colors"
-          >
-            <span className="text-sm font-bold leading-none">•</span>
-          </button>
-        )}
         {onAnswer && entry.type === 'question' && (
           <button
             onClick={(e) => {

--- a/frontend/src/components/bujo/OverviewView.tsx
+++ b/frontend/src/components/bujo/OverviewView.tsx
@@ -1,6 +1,6 @@
 import { Entry, ENTRY_SYMBOLS, PRIORITY_SYMBOLS } from '@/types/bujo';
 import { cn } from '@/lib/utils';
-import { Clock, Check, ChevronDown, ChevronRight, X, RotateCcw, Trash2, Pencil, ArrowRight, Flag, RefreshCw } from 'lucide-react';
+import { Clock, ChevronDown, ChevronRight, X, RotateCcw, Trash2, Pencil, ArrowRight, Flag, RefreshCw } from 'lucide-react';
 import { ContextPill } from './ContextPill';
 import { format, parseISO } from 'date-fns';
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -318,12 +318,31 @@ export function OverviewView({ overdueEntries, onEntryChanged, onError, onMigrat
                                 onClick={() => toggleExpanded(entry.id)}
                               />
                             )}
-                            <span
-                              data-testid="entry-symbol"
-                              className="w-5 text-center text-muted-foreground font-mono"
-                            >
-                              {ENTRY_SYMBOLS[entry.type]}
-                            </span>
+                            {/* Symbol - clickable for task/done entries */}
+                            {entry.type === 'task' || entry.type === 'done' ? (
+                              <button
+                                data-testid="entry-symbol"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (entry.type === 'task') {
+                                    handleMarkDone(entry);
+                                  } else {
+                                    handleMarkUndone(entry);
+                                  }
+                                }}
+                                title={entry.type === 'task' ? 'Mark done' : 'Mark undone'}
+                                className="w-5 text-center text-muted-foreground font-mono cursor-pointer hover:opacity-70 transition-opacity"
+                              >
+                                {ENTRY_SYMBOLS[entry.type]}
+                              </button>
+                            ) : (
+                              <span
+                                data-testid="entry-symbol"
+                                className="w-5 text-center text-muted-foreground font-mono"
+                              >
+                                {ENTRY_SYMBOLS[entry.type]}
+                              </span>
+                            )}
                             <span className={cn(
                               'flex-1 text-sm',
                               entry.type === 'done' && 'text-bujo-done',
@@ -335,27 +354,6 @@ export function OverviewView({ overdueEntries, onEntryChanged, onError, onMigrat
                               <span className="text-xs text-warning font-medium">
                                 {PRIORITY_SYMBOLS[entry.priority]}
                               </span>
-                            )}
-                            {entry.type === 'done' ? (
-                              <button
-                                data-action-slot
-                                onClick={(e) => { e.stopPropagation(); handleMarkUndone(entry); }}
-                                title="Mark undone"
-                                className="p-1 rounded hover:bg-orange-500/20 text-muted-foreground hover:text-orange-600 transition-colors opacity-0 group-hover:opacity-100"
-                              >
-                                <span className="text-sm font-bold leading-none">•</span>
-                              </button>
-                            ) : entry.type !== 'cancelled' ? (
-                              <button
-                                data-action-slot
-                                onClick={(e) => { e.stopPropagation(); handleMarkDone(entry); }}
-                                title="Mark done"
-                                className="p-1 rounded hover:bg-bujo-done/20 text-muted-foreground hover:text-bujo-done transition-colors opacity-0 group-hover:opacity-100"
-                              >
-                                <Check className="w-4 h-4" />
-                              </button>
-                            ) : (
-                              <ActionPlaceholder />
                             )}
                             {entry.type !== 'cancelled' ? (
                               <button

--- a/frontend/src/components/bujo/SearchView.tsx
+++ b/frontend/src/components/bujo/SearchView.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Search as SearchIcon, Check, X, RotateCcw, Trash2, Pencil, ArrowRight, Flag, RefreshCw, MessageCircle } from 'lucide-react';
+import { Search as SearchIcon, X, RotateCcw, Trash2, Pencil, ArrowRight, Flag, RefreshCw, MessageCircle } from 'lucide-react';
 import { Search, GetEntry, GetEntryAncestors, MarkEntryDone, MarkEntryUndone, CancelEntry, UncancelEntry, DeleteEntry, CyclePriority, RetypeEntry } from '@/wailsjs/go/wails/App';
 import { ContextPill } from './ContextPill';
 import { format } from 'date-fns';
@@ -427,16 +427,33 @@ export function SearchView({ onMigrate, onNavigateToEntry }: SearchViewProps) {
                   />
                 )}
                 <span className="inline-flex items-center gap-1 flex-shrink-0">
-                  <span className={cn(
-                    'text-lg font-mono w-5 text-center',
-                    result.type === 'done' && 'text-bujo-done',
-                    result.type === 'task' && 'text-bujo-task',
-                    result.type === 'note' && 'text-bujo-note',
-                    result.type === 'event' && 'text-bujo-event',
-                    result.type === 'cancelled' && 'text-bujo-cancelled',
-                  )}>
-                    {getSymbol(result.type)}
-                  </span>
+                  {/* Symbol - clickable for task/done entries */}
+                  {result.type === 'task' || result.type === 'done' ? (
+                    <button
+                      data-testid="entry-symbol"
+                      onClick={(e) => result.type === 'task' ? handleMarkDone(result.id, e) : handleMarkUndone(result.id, e)}
+                      title={result.type === 'task' ? 'Mark done' : 'Mark undone'}
+                      className={cn(
+                        'text-lg font-mono w-5 text-center cursor-pointer hover:opacity-70 transition-opacity',
+                        result.type === 'done' && 'text-bujo-done',
+                        result.type === 'task' && 'text-bujo-task',
+                      )}
+                    >
+                      {getSymbol(result.type)}
+                    </button>
+                  ) : (
+                    <span
+                      data-testid="entry-symbol"
+                      className={cn(
+                        'text-lg font-mono w-5 text-center',
+                        result.type === 'note' && 'text-bujo-note',
+                        result.type === 'event' && 'text-bujo-event',
+                        result.type === 'cancelled' && 'text-bujo-cancelled',
+                      )}
+                    >
+                      {getSymbol(result.type)}
+                    </span>
+                  )}
                   {result.priority !== 'none' && (
                     <span className={cn(
                       'text-xs font-bold',
@@ -462,25 +479,7 @@ export function SearchView({ onMigrate, onNavigateToEntry }: SearchViewProps) {
                 </div>
 
                 {/* Action buttons */}
-                {result.type === 'task' ? (
-                  <button
-                    data-action-slot
-                    onClick={(e) => handleMarkDone(result.id, e)}
-                    title="Mark done"
-                    className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-bujo-done"
-                  >
-                    <Check className="w-4 h-4" />
-                  </button>
-                ) : result.type === 'done' ? (
-                  <button
-                    data-action-slot
-                    onClick={(e) => handleMarkUndone(result.id, e)}
-                    title="Mark undone"
-                    className="p-1 rounded hover:bg-orange-500/20 text-muted-foreground hover:text-orange-600"
-                  >
-                    <span className="text-sm font-bold leading-none">•</span>
-                  </button>
-                ) : result.type === 'question' ? (
+                {result.type === 'question' ? (
                   <button
                     data-action-slot
                     onClick={(e) => { e.stopPropagation(); handleAnswer(result); }}


### PR DESCRIPTION
## Summary
- Make entry symbols (• for tasks, ✓ for done) clickable to toggle task completion status
- Apply this behavior consistently across EntryItem, OverviewView, and SearchView
- Remove redundant Check icon action buttons (now clicking symbol serves this purpose)
- Preserve keyboard navigation (j/k navigation, spacebar toggle)

## Test plan
- [x] Verify clicking task bullet (•) marks task as done
- [x] Verify clicking checkmark (✓) marks task as undone
- [x] Verify keyboard navigation (j/k, spacebar) still works
- [x] Verify other action buttons still work (cancel, delete, migrate, etc.)
- [x] All 683 tests pass

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)