### PR TITLE
feat: Add moveToList and navigateToEntry actions to OverviewView and SearchView

### DIFF
--- a/frontend/src/components/bujo/EntryActions/EntryActionBar.tsx
+++ b/frontend/src/components/bujo/EntryActions/EntryActionBar.tsx
@@ -36,6 +36,7 @@ const callbackMap: Record<EntryActionType, keyof ActionCallbacks> = {
   addChild: 'onAddChild',
   moveToRoot: 'onMoveToRoot',
   moveToList: 'onMoveToList',
+  navigateToEntry: 'onNavigateToEntry',
 };
 
 export function EntryActionBar({

--- a/frontend/src/components/bujo/EntryActions/types.ts
+++ b/frontend/src/components/bujo/EntryActions/types.ts
@@ -1,5 +1,5 @@
 import { Entry, EntryType } from '@/types/bujo';
-import { LucideIcon, MessageCircle, X, RotateCcw, Flag, RefreshCw, ArrowRight, Pencil, Trash2, CornerDownRight, ArrowUpToLine, ListPlus } from 'lucide-react';
+import { LucideIcon, MessageCircle, X, RotateCcw, Flag, RefreshCw, ArrowRight, Pencil, Trash2, CornerDownRight, ArrowUpToLine, ListPlus, Calendar } from 'lucide-react';
 
 export type EntryActionType =
   | 'answer'
@@ -12,7 +12,8 @@ export type EntryActionType =
   | 'delete'
   | 'addChild'
   | 'moveToRoot'
-  | 'moveToList';
+  | 'moveToList'
+  | 'navigateToEntry';
 
 export interface ActionContext {
   hasParent?: boolean;
@@ -47,6 +48,7 @@ export interface ActionCallbacks {
   onAddChild?: () => void;
   onMoveToRoot?: () => void;
   onMoveToList?: () => void;
+  onNavigateToEntry?: () => void;
 }
 
 const CYCLEABLE_TYPES: EntryType[] = ['task', 'note', 'event', 'question'];
@@ -158,7 +160,17 @@ export const ACTION_REGISTRY: Record<EntryActionType, ActionConfig> = {
     label: 'Move to list',
     title: 'Move to list',
     appliesTo: (entry) => entry.type === 'task',
-    showInBar: false,
+    showInBar: true,
+    showInMenu: true,
+    hoverClass: 'hover:bg-primary/20 hover:text-primary',
+  },
+  navigateToEntry: {
+    type: 'navigateToEntry',
+    icon: Calendar,
+    label: 'Go to date',
+    title: 'Go to date',
+    appliesTo: () => true,
+    showInBar: true,
     showInMenu: true,
     hoverClass: 'hover:bg-primary/20 hover:text-primary',
   },
@@ -171,6 +183,8 @@ export const BAR_ACTION_ORDER: EntryActionType[] = [
   'cyclePriority',
   'cycleType',
   'migrate',
+  'moveToList',
+  'navigateToEntry',
   'edit',
   'delete',
 ];
@@ -181,6 +195,7 @@ export const MENU_ACTION_ORDER: EntryActionType[] = [
   'uncancel',
   'migrate',
   'moveToList',
+  'navigateToEntry',
   'cycleType',
   'cyclePriority',
   'moveToRoot',

--- a/frontend/src/components/bujo/EntryActions/useEntryActions.test.ts
+++ b/frontend/src/components/bujo/EntryActions/useEntryActions.test.ts
@@ -110,7 +110,7 @@ describe('useEntryActions', () => {
       const actions = getApplicableBarActions(task);
       const types = actions.map(a => a.type);
 
-      const expectedOrder = ['cancel', 'cyclePriority', 'cycleType', 'migrate', 'edit', 'delete'];
+      const expectedOrder = ['cancel', 'cyclePriority', 'cycleType', 'migrate', 'moveToList', 'navigateToEntry', 'edit', 'delete'];
       expect(types).toEqual(expectedOrder);
     });
 
@@ -119,7 +119,7 @@ describe('useEntryActions', () => {
       const actions = getApplicableBarActions(question);
       const types = actions.map(a => a.type);
 
-      const expectedOrder = ['answer', 'cancel', 'cyclePriority', 'cycleType', 'edit', 'delete'];
+      const expectedOrder = ['answer', 'cancel', 'cyclePriority', 'cycleType', 'navigateToEntry', 'edit', 'delete'];
       expect(types).toEqual(expectedOrder);
     });
   });

--- a/frontend/src/components/bujo/ListPickerModal.test.tsx
+++ b/frontend/src/components/bujo/ListPickerModal.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ListPickerModal } from './ListPickerModal';
+
+vi.mock('@/wailsjs/go/wails/App', () => ({
+  GetLists: vi.fn(),
+}));
+
+import { GetLists } from '@/wailsjs/go/wails/App';
+
+const mockLists = [
+  { ID: 1, Name: 'Shopping', Items: [{ ID: 101 }, { ID: 102 }] },
+  { ID: 2, Name: 'Work Tasks', Items: [{ ID: 201 }] },
+  { ID: 3, Name: 'Empty List', Items: [] },
+];
+
+describe('ListPickerModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (GetLists as ReturnType<typeof vi.fn>).mockResolvedValue(mockLists);
+  });
+
+  describe('visibility', () => {
+    it('renders nothing when isOpen is false', () => {
+      render(
+        <ListPickerModal
+          isOpen={false}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText('Move to List')).not.toBeInTheDocument();
+    });
+
+    it('renders modal when isOpen is true', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Move to List')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('content display', () => {
+    it('displays entry content in the modal', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Buy groceries"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Buy groceries/)).toBeInTheDocument();
+      });
+    });
+
+    it('displays all available lists', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Shopping')).toBeInTheDocument();
+        expect(screen.getByText('Work Tasks')).toBeInTheDocument();
+        expect(screen.getByText('Empty List')).toBeInTheDocument();
+      });
+    });
+
+    it('displays item count for each list', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('2 items')).toBeInTheDocument();
+        expect(screen.getByText('1 items')).toBeInTheDocument();
+        expect(screen.getByText('0 items')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('selection', () => {
+    it('selects first list by default', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        const shoppingLabel = screen.getByText('Shopping').closest('label');
+        expect(shoppingLabel).toHaveClass('border-primary');
+      });
+    });
+
+    it('allows selecting a different list', async () => {
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Work Tasks')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Work Tasks'));
+
+      const workTasksLabel = screen.getByText('Work Tasks').closest('label');
+      expect(workTasksLabel).toHaveClass('border-primary');
+    });
+  });
+
+  describe('callbacks', () => {
+    it('calls onSelect with list ID when Move button clicked', async () => {
+      const onSelect = vi.fn();
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={onSelect}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Shopping')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('calls onSelect with selected list ID', async () => {
+      const onSelect = vi.fn();
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={onSelect}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Work Tasks')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Work Tasks'));
+      fireEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('calls onCancel when Cancel button clicked', async () => {
+      const onCancel = vi.fn();
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={onCancel}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows message when no lists exist', async () => {
+      (GetLists as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/No lists found/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows Close button instead of Move when no lists exist', async () => {
+      (GetLists as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Move' })).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading message while fetching lists', async () => {
+      (GetLists as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise(() => {})
+      );
+
+      render(
+        <ListPickerModal
+          isOpen={true}
+          entryContent="Test entry"
+          onSelect={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText(/Loading lists/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/bujo/ListPickerModal.tsx
+++ b/frontend/src/components/bujo/ListPickerModal.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import { GetLists } from '@/wailsjs/go/wails/App';
+import { wails } from '@/wailsjs/go/models';
+import { List } from 'lucide-react';
+
+interface ListPickerModalProps {
+  isOpen: boolean;
+  entryContent: string;
+  onSelect: (listId: number) => void;
+  onCancel: () => void;
+}
+
+export function ListPickerModal({ isOpen, entryContent, onSelect, onCancel }: ListPickerModalProps) {
+  const [lists, setLists] = useState<wails.ListWithItems[]>([]);
+  const [hasFetched, setHasFetched] = useState(false);
+  const [selectedListId, setSelectedListId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      // Reset fetch status when modal closes to refetch on next open
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setHasFetched(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || hasFetched) return;
+
+    GetLists()
+      .then((fetchedLists) => {
+        setLists(fetchedLists || []);
+        if (fetchedLists && fetchedLists.length > 0) {
+          setSelectedListId(fetchedLists[0].ID);
+        }
+        setHasFetched(true);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch lists:', err);
+        setLists([]);
+        setHasFetched(true);
+      });
+  }, [isOpen, hasFetched]);
+
+  const loading = isOpen && !hasFetched;
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (selectedListId !== null) {
+      onSelect(selectedListId);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-background rounded-lg shadow-lg p-6 w-full max-w-md animate-fade-in">
+        <h2 className="text-lg font-semibold mb-4">Move to List</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Move &ldquo;{entryContent}&rdquo; to a list:
+        </p>
+        {loading ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">Loading lists...</p>
+        ) : lists.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No lists found. Create a list first.
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-2 mb-4 max-h-60 overflow-y-auto">
+              {lists.map((list) => (
+                <label
+                  key={list.ID}
+                  className={cn(
+                    'flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors',
+                    selectedListId === list.ID
+                      ? 'border-primary bg-primary/10'
+                      : 'border-border hover:bg-secondary/50'
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="list"
+                    value={list.ID}
+                    checked={selectedListId === list.ID}
+                    onChange={() => setSelectedListId(list.ID)}
+                    className="sr-only"
+                  />
+                  <List className="w-4 h-4 text-muted-foreground" />
+                  <span className="flex-1 text-sm">{list.Name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {list.Items?.length || 0} items
+                  </span>
+                </label>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-4 py-2 rounded-lg text-sm bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={selectedListId === null}
+                className={cn(
+                  'px-4 py-2 rounded-lg text-sm transition-colors',
+                  selectedListId !== null
+                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                    : 'bg-muted text-muted-foreground cursor-not-allowed'
+                )}
+              >
+                Move
+              </button>
+            </div>
+          </form>
+        )}
+        {lists.length === 0 && !loading && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2 rounded-lg text-sm bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/bujo/OverviewView.test.tsx
+++ b/frontend/src/components/bujo/OverviewView.test.tsx
@@ -729,3 +729,74 @@ describe('OverviewView - Action Icon Placeholders', () => {
     expect(taskActionSlots?.length).toBe(doneActionSlots?.length)
   })
 })
+
+describe('OverviewView - Move to List', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows move to list button for task entries when onMoveToList provided', () => {
+    render(<OverviewView overdueEntries={[createTestEntry({ type: 'task' })]} onMoveToList={vi.fn()} />)
+    expect(screen.getByTitle('Move to list')).toBeInTheDocument()
+  })
+
+  it('does not show move to list button when onMoveToList not provided', () => {
+    render(<OverviewView overdueEntries={[createTestEntry({ type: 'task' })]} />)
+    expect(screen.queryByTitle('Move to list')).not.toBeInTheDocument()
+  })
+
+  it('does not show move to list button for cancelled entries', () => {
+    render(<OverviewView overdueEntries={[createTestEntry({ type: 'cancelled' })]} onMoveToList={vi.fn()} />)
+    expect(screen.queryByTitle('Move to list')).not.toBeInTheDocument()
+  })
+
+  it('calls onMoveToList when move to list button is clicked', async () => {
+    const user = userEvent.setup()
+    const onMoveToList = vi.fn()
+    const entry = createTestEntry({ id: 42, type: 'task' })
+    render(<OverviewView overdueEntries={[entry]} onMoveToList={onMoveToList} />)
+
+    await user.click(screen.getByTitle('Move to list'))
+
+    expect(onMoveToList).toHaveBeenCalledWith(entry)
+  })
+})
+
+describe('OverviewView - Navigate to Entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows go to date button when onNavigateToEntry provided', () => {
+    render(<OverviewView overdueEntries={[createTestEntry({ type: 'task' })]} onNavigateToEntry={vi.fn()} />)
+    expect(screen.getByTitle('Go to date')).toBeInTheDocument()
+  })
+
+  it('does not show go to date button when onNavigateToEntry not provided', () => {
+    render(<OverviewView overdueEntries={[createTestEntry({ type: 'task' })]} />)
+    expect(screen.queryByTitle('Go to date')).not.toBeInTheDocument()
+  })
+
+  it('calls onNavigateToEntry when go to date button is clicked', async () => {
+    const user = userEvent.setup()
+    const onNavigateToEntry = vi.fn()
+    const entry = createTestEntry({ id: 42, type: 'task', loggedDate: '2026-01-15' })
+    render(<OverviewView overdueEntries={[entry]} onNavigateToEntry={onNavigateToEntry} />)
+
+    await user.click(screen.getByTitle('Go to date'))
+
+    expect(onNavigateToEntry).toHaveBeenCalledWith(entry)
+  })
+
+  it('shows go to date button for all entry types', () => {
+    const entries = [
+      createTestEntry({ id: 1, type: 'task' }),
+      createTestEntry({ id: 2, type: 'done' }),
+      createTestEntry({ id: 3, type: 'cancelled' }),
+    ]
+    render(<OverviewView overdueEntries={entries} onNavigateToEntry={vi.fn()} />)
+
+    const goToDateButtons = screen.getAllByTitle('Go to date')
+    expect(goToDateButtons).toHaveLength(3)
+  })
+})

--- a/frontend/src/components/bujo/OverviewView.tsx
+++ b/frontend/src/components/bujo/OverviewView.tsx
@@ -13,6 +13,8 @@ interface OverviewViewProps {
   onError?: (message: string) => void;
   onMigrate?: (entry: Entry) => void;
   onEdit?: (entry: Entry) => void;
+  onMoveToList?: (entry: Entry) => void;
+  onNavigateToEntry?: (entry: Entry) => void;
 }
 
 function groupByDate(entries: Entry[]): Map<string, Entry[]> {
@@ -48,7 +50,7 @@ function buildParentChain(entry: Entry, entriesById: Map<number, Entry>): Entry[
   return chain;
 }
 
-export function OverviewView({ overdueEntries, onEntryChanged, onError, onMigrate, onEdit }: OverviewViewProps) {
+export function OverviewView({ overdueEntries, onEntryChanged, onError, onMigrate, onEdit, onMoveToList, onNavigateToEntry }: OverviewViewProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -361,6 +363,8 @@ export function OverviewView({ overdueEntries, onEntryChanged, onError, onMigrat
                                 onCyclePriority: () => handleCyclePriority(entry),
                                 onCycleType: () => handleCycleType(entry),
                                 onMigrate: onMigrate ? () => onMigrate(entry) : undefined,
+                                onMoveToList: onMoveToList ? () => onMoveToList(entry) : undefined,
+                                onNavigateToEntry: onNavigateToEntry ? () => onNavigateToEntry(entry) : undefined,
                                 onEdit: onEdit ? () => onEdit(entry) : undefined,
                                 onDelete: () => handleDelete(entry),
                               }}

--- a/frontend/src/components/bujo/SearchView.test.tsx
+++ b/frontend/src/components/bujo/SearchView.test.tsx
@@ -1192,6 +1192,172 @@ describe('SearchView - Double Click Navigation', () => {
   })
 })
 
+describe('SearchView - Move to List', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows move to list button for task entries when onMoveToList provided', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Test task', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView onMoveToList={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Move to list')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show move to list button for non-task entries', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Test note', Type: 'note', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView onMoveToList={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test note')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTitle('Move to list')).not.toBeInTheDocument()
+  })
+
+  it('does not show move to list button when onMoveToList not provided', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Test task', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test task')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTitle('Move to list')).not.toBeInTheDocument()
+  })
+
+  it('calls onMoveToList when move to list button is clicked', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 42, Content: 'Test task', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const onMoveToList = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchView onMoveToList={onMoveToList} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Move to list')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByTitle('Move to list'))
+
+    expect(onMoveToList).toHaveBeenCalledWith(expect.objectContaining({ id: 42, type: 'task', content: 'Test task' }))
+  })
+})
+
+describe('SearchView - Navigate to Entry Button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows go to date button when onNavigateToEntry provided', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView onNavigateToEntry={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Go to date')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show go to date button when onNavigateToEntry not provided', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test entry')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTitle('Go to date')).not.toBeInTheDocument()
+  })
+
+  it('calls onNavigateToEntry when go to date button is clicked', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 42, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const onNavigateToEntry = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchView onNavigateToEntry={onNavigateToEntry} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Go to date')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByTitle('Go to date'))
+
+    expect(onNavigateToEntry).toHaveBeenCalledWith(expect.objectContaining({ id: 42, type: 'task', content: 'Test entry' }))
+  })
+
+  it('go to date button works independently of double-click navigation', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 42, Content: 'Test entry', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const onNavigateToEntry = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchView onNavigateToEntry={onNavigateToEntry} />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Go to date')).toBeInTheDocument()
+    })
+
+    // First use the button
+    await user.click(screen.getByTitle('Go to date'))
+    expect(onNavigateToEntry).toHaveBeenCalledTimes(1)
+
+    // Then also verify double-click still works
+    const result = screen.getByText('Test entry').closest('[data-result-id]')
+    await user.dblClick(result!)
+    expect(onNavigateToEntry).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('SearchView - Symbol Click Toggle', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/components/bujo/SearchView.tsx
+++ b/frontend/src/components/bujo/SearchView.tsx
@@ -26,10 +26,11 @@ interface AncestorEntry {
 interface SearchViewProps {
   onMigrate?: (entry: SearchResult) => void;
   onNavigateToEntry?: (entry: SearchResult) => void;
+  onMoveToList?: (entry: SearchResult) => void;
   onEdit?: (entry: SearchResult) => void;
 }
 
-export function SearchView({ onMigrate, onNavigateToEntry, onEdit }: SearchViewProps) {
+export function SearchView({ onMigrate, onNavigateToEntry, onMoveToList, onEdit }: SearchViewProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
@@ -481,6 +482,8 @@ export function SearchView({ onMigrate, onNavigateToEntry, onEdit }: SearchViewP
                     onCyclePriority: () => handleCyclePriority(result.id),
                     onCycleType: () => handleCycleType(result.id, result.type),
                     onMigrate: onMigrate ? () => onMigrate(result) : undefined,
+                    onMoveToList: onMoveToList ? () => onMoveToList(result) : undefined,
+                    onNavigateToEntry: onNavigateToEntry ? () => onNavigateToEntry(result) : undefined,
                     onEdit: onEdit ? () => onEdit(result) : undefined,
                     onDelete: () => handleDelete(result.id),
                   }}


### PR DESCRIPTION
## Summary
- Add ListPickerModal component with full test coverage (13 tests)
- Add `onMoveToList` and `onNavigateToEntry` props to OverviewView and SearchView
- Wire up all handlers and modal in App.tsx
- Add `moveToList` and `navigateToEntry` to the ACTION_REGISTRY

## Test plan
- [x] All 748 tests pass
- [x] ListPickerModal shows available lists
- [x] Moving to list adds entry content as list item
- [x] Navigate to entry switches to weekly review at entry date
- [x] Actions show correctly in action bar based on entry type

Fixes #368
Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)