### PR TITLE
fix(service): Restore Overdue field to MultiDayAgenda for Wails build

### DIFF
--- a/internal/service/bujo.go
+++ b/internal/service/bujo.go
@@ -102,7 +102,8 @@ type DayEntries struct {
 }
 
 type MultiDayAgenda struct {
-	Days []DayEntries
+	Overdue []domain.Entry
+	Days    []DayEntries
 }
 
 func (s *BujoService) GetDailyAgenda(ctx context.Context, date time.Time) (*DailyAgenda, error) {
@@ -131,6 +132,12 @@ func (s *BujoService) GetDailyAgenda(ctx context.Context, date time.Time) (*Dail
 
 func (s *BujoService) GetMultiDayAgenda(ctx context.Context, from, to time.Time) (*MultiDayAgenda, error) {
 	agenda := &MultiDayAgenda{}
+
+	overdue, err := s.entryRepo.GetOverdue(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	agenda.Overdue = overdue
 
 	entries, err := s.entryRepo.GetByDateRange(ctx, from, to)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Restores `Overdue []domain.Entry` field to `MultiDayAgenda` struct
- Populates overdue entries by calling `entryRepo.GetOverdue()` in `GetMultiDayAgenda`
- Fixes CI build failure where Wails regenerates bindings without the `Overdue` field

## Root Cause
PR #382 removed the `Overdue` field from the Go struct but the frontend `App.tsx` still references `agendaData?.Overdue`. The committed `models.ts` had the field, but CI regenerates bindings from Go code, causing the mismatch.

## Test plan
- [x] Added `TestBujoService_GetMultiDayAgenda_IncludesOverdueEntries` test
- [x] All existing `GetMultiDayAgenda` tests pass
- [ ] CI Wails build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)