### PR TITLE
fix: Add tag_regex to handle non-semver nightly build tags

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+git:
+  tag_regex: ^build-(\d+)$
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
## Summary
- Adds `git.tag_regex` to `.goreleaser.nightly.yaml` to handle `build-N` format tags
- GoReleaser requires semver by default, but nightly builds use `build-25` style tags
- The regex extracts the build number, allowing GoReleaser to proceed

## Test plan
- [ ] Trigger nightly workflow manually with force build
- [ ] Verify GoReleaser no longer fails with semver parsing error
