### PR TITLE
fix: Remove invalid tag_regex from goreleaser config

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-git:
-  tag_regex: ^build-(\d+)$
-
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
The tag_regex field doesn't exist in GoReleaser v2's git config. The workflow already uses semver-compliant v0.0.N tags, so no custom regex is needed.