### PR TITLE
feat: Add zsh completions to Homebrew formula

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -71,6 +71,8 @@ brews:
     license: "MIT"
     install: |
       bin.install "bujo"
+    post_install: |
+      (zsh_completion/"_bujo").write `#{bin}/bujo completion zsh`
     test: |
       system "#{bin}/bujo", "version"
     caveats: |


### PR DESCRIPTION
## Summary
- Adds `post_install` hook to goreleaser brews config
- Generates zsh completions using `bujo completion zsh`
- Installs completions to Homebrew's standard zsh_completion directory

## Test plan
- [ ] Nightly build publishes updated formula to homebrew-tap
- [ ] Formula contains `post_install` method
- [ ] Fresh install creates `_bujo` in `/opt/homebrew/share/zsh/site-functions`
- [ ] Zsh tab completion works after new shell session

Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)