### PR TITLE
fix: Display correct day labels in habit tracker week view

### DIFF
--- a/frontend/src/components/bujo/HabitTracker.test.tsx
+++ b/frontend/src/components/bujo/HabitTracker.test.tsx
@@ -640,6 +640,50 @@ describe('HabitTracker - Week View Header', () => {
   })
 })
 
+describe('HabitTracker - Week View Dynamic Day Labels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // Wednesday Jan 22, 2025
+    vi.setSystemTime(new Date('2025-01-22T12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows day labels matching actual days displayed (past 7 days ending with anchor)', () => {
+    // Anchor is Wednesday Jan 22, 2025
+    // Past 7 days: Thu 16, Fri 17, Sat 18, Sun 19, Mon 20, Tue 21, Wed 22
+    // Labels should be: T, F, S, S, M, T, W (not S, M, T, W, T, F, S)
+    const anchor = new Date('2025-01-22')
+    const habit = createTestHabit({
+      dayHistory: [
+        { date: '2025-01-16', completed: false, count: 0 },
+        { date: '2025-01-17', completed: false, count: 0 },
+        { date: '2025-01-18', completed: false, count: 0 },
+        { date: '2025-01-19', completed: false, count: 0 },
+        { date: '2025-01-20', completed: false, count: 0 },
+        { date: '2025-01-21', completed: false, count: 0 },
+        { date: '2025-01-22', completed: false, count: 0 },
+      ]
+    })
+    render(<HabitTracker habits={[habit]} anchorDate={anchor} />)
+
+    // The header should show labels matching the actual days:
+    // Thu=T, Fri=F, Sat=S, Sun=S, Mon=M, Tue=T, Wed=W
+    // So we expect: T, F, S, S, M, T, W
+    const headerLabels = screen.getAllByText(/^[SMTWF]$/)
+
+    // Should have exactly 7 labels in the header
+    expect(headerLabels).toHaveLength(7)
+
+    // Extract text content to verify order
+    const labelTexts = headerLabels.map(el => el.textContent)
+    expect(labelTexts).toEqual(['T', 'F', 'S', 'S', 'M', 'T', 'W'])
+  })
+})
+
 describe('HabitTracker - No Re-render Animation', () => {
   it('habit rows do not have slide-in animation that would flicker on re-render', () => {
     const habit = createTestHabit({ name: 'Exercise' })

--- a/frontend/src/components/bujo/HabitTracker.tsx
+++ b/frontend/src/components/bujo/HabitTracker.tsx
@@ -16,6 +16,8 @@ import {
 
 type PeriodView = 'week' | 'month' | 'quarter';
 
+const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
 interface HabitTrackerProps {
   habits: Habit[];
   onHabitChanged?: () => void;
@@ -444,12 +446,12 @@ export function HabitTracker({ habits, onHabitChanged, period, onPeriodChange, a
           <div className="flex-shrink-0 w-32" />
           <div className="flex-1">
             <div className="grid grid-cols-7 gap-px mb-1">
-              {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((label, i) => (
+              {getWeekDates(effectiveAnchor).map((day, i) => (
                 <div
                   key={i}
                   className="w-full flex justify-center text-[10px] text-muted-foreground font-medium"
                 >
-                  {label}
+                  {DAY_LABELS[day.dayOfWeek]}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Fixes incorrect day labels in habit tracker week view header
- Labels now dynamically match the actual days displayed (past 7 days ending with anchor)
- Previously showed hardcoded S-M-T-W-T-F-S assuming a calendar week starting Sunday

## Test plan

- [x] Added test verifying labels match actual days displayed
- [x] All 760 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] Lint passes

Fixes #406

🤖 Generated with [Claude Code](https://claude.ai/code)