### PR TITLE
fix: Allow setting location, mood, weather for past days in today view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -534,6 +534,7 @@ function App() {
           currentMood={today?.mood}
           currentWeather={today?.weather}
           currentLocation={today?.location}
+          currentDate={currentDate}
           onMoodChanged={loadData}
           onWeatherChanged={loadData}
           onLocationChanged={loadData}

--- a/frontend/src/components/bujo/Header.test.tsx
+++ b/frontend/src/components/bujo/Header.test.tsx
@@ -255,3 +255,64 @@ describe('Header - Location', () => {
     })
   })
 })
+
+describe('Header - currentDate prop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses currentDate prop for SetMood API call instead of today', async () => {
+    const user = userEvent.setup()
+    const pastDate = new Date('2026-01-15')
+    render(<Header title="Today" currentDate={pastDate} />)
+
+    await user.click(screen.getByTitle('Set mood'))
+    await user.click(screen.getByText('😊'))
+
+    await waitFor(() => {
+      expect(SetMood).toHaveBeenCalled()
+      const call = vi.mocked(SetMood).mock.calls[0]
+      const dateArg = new Date(call[0] as unknown as string)
+      expect(dateArg.toDateString()).toBe(pastDate.toDateString())
+    })
+  })
+
+  it('uses currentDate prop for SetWeather API call instead of today', async () => {
+    const user = userEvent.setup()
+    const pastDate = new Date('2026-01-15')
+    render(<Header title="Today" currentDate={pastDate} />)
+
+    await user.click(screen.getByTitle('Set weather'))
+    await user.click(screen.getByText('☀️'))
+
+    await waitFor(() => {
+      expect(SetWeather).toHaveBeenCalled()
+      const call = vi.mocked(SetWeather).mock.calls[0]
+      const dateArg = new Date(call[0] as unknown as string)
+      expect(dateArg.toDateString()).toBe(pastDate.toDateString())
+    })
+  })
+
+  it('uses currentDate prop for SetLocation API call instead of today', async () => {
+    const user = userEvent.setup()
+    const pastDate = new Date('2026-01-15')
+    render(<Header title="Today" currentDate={pastDate} />)
+
+    await user.click(screen.getByTitle('Set location'))
+    await user.click(screen.getByText('🏢'))
+
+    await waitFor(() => {
+      expect(SetLocation).toHaveBeenCalled()
+      const call = vi.mocked(SetLocation).mock.calls[0]
+      const dateArg = new Date(call[0] as unknown as string)
+      expect(dateArg.toDateString()).toBe(pastDate.toDateString())
+    })
+  })
+
+  it('displays the currentDate in header when provided', () => {
+    const pastDate = new Date('2026-01-15')
+    render(<Header title="Today" currentDate={pastDate} />)
+
+    expect(screen.getByText('Thursday, January 15, 2026')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/bujo/Header.tsx
+++ b/frontend/src/components/bujo/Header.tsx
@@ -41,6 +41,7 @@ interface HeaderProps {
   currentMood?: string;
   currentWeather?: string;
   currentLocation?: string;
+  currentDate?: Date;
   onMoodChanged?: () => void;
   onWeatherChanged?: () => void;
   onLocationChanged?: () => void;
@@ -52,11 +53,12 @@ export function Header({
   currentMood,
   currentWeather,
   currentLocation,
+  currentDate,
   onMoodChanged,
   onWeatherChanged,
   onLocationChanged,
 }: HeaderProps) {
-  const today = new Date();
+  const displayDate = currentDate ?? new Date();
   const [showMoodPicker, setShowMoodPicker] = useState(false);
   const [showWeatherPicker, setShowWeatherPicker] = useState(false);
   const [showLocationPicker, setShowLocationPicker] = useState(false);
@@ -90,20 +92,20 @@ export function Header({
   }, [showLocationPicker]);
 
   const handleMoodSelect = async (mood: MoodValue) => {
-    await SetMood(today.toISOString(), mood);
+    await SetMood(displayDate.toISOString(), mood);
     setShowMoodPicker(false);
     onMoodChanged?.();
   };
 
   const handleWeatherSelect = async (weather: WeatherValue) => {
-    await SetWeather(today.toISOString(), weather);
+    await SetWeather(displayDate.toISOString(), weather);
     setShowWeatherPicker(false);
     onWeatherChanged?.();
   };
 
   const handleLocationSelect = async (location: string) => {
     if (!location.trim()) return;
-    await SetLocation(today.toISOString(), location);
+    await SetLocation(displayDate.toISOString(), location);
     setShowLocationPicker(false);
     setLocationInput('');
     onLocationChanged?.();
@@ -134,7 +136,7 @@ export function Header({
         <h2 className="font-display text-2xl font-semibold">{title}</h2>
         <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
           <Calendar className="w-4 h-4" />
-          {format(today, 'EEEE, MMMM d, yyyy')}
+          {format(displayDate, 'EEEE, MMMM d, yyyy')}
         </span>
 
         {/* Mood button */}

--- a/internal/service/bujo.go
+++ b/internal/service/bujo.go
@@ -209,11 +209,15 @@ func (s *BujoService) GetEntry(ctx context.Context, id int64) (*domain.Entry, er
 }
 
 func (s *BujoService) SetLocation(ctx context.Context, date time.Time, location string) error {
-	dayCtx := domain.DayContext{
-		Date:     date,
-		Location: &location,
+	dayCtx, err := s.dayCtxRepo.GetByDate(ctx, date)
+	if err != nil {
+		return err
 	}
-	return s.dayCtxRepo.Upsert(ctx, dayCtx)
+	if dayCtx == nil {
+		dayCtx = &domain.DayContext{Date: date}
+	}
+	dayCtx.Location = &location
+	return s.dayCtxRepo.Upsert(ctx, *dayCtx)
 }
 
 func (s *BujoService) GetLocationHistory(ctx context.Context, from, to time.Time) ([]domain.DayContext, error) {

--- a/internal/service/bujo_test.go
+++ b/internal/service/bujo_test.go
@@ -217,6 +217,31 @@ func TestBujoService_ClearLocation(t *testing.T) {
 	assert.Nil(t, loc)
 }
 
+func TestBujoService_SetLocation_PreservesExistingMoodAndWeather(t *testing.T) {
+	service, _, dayCtxRepo := setupBujoService(t)
+	ctx := context.Background()
+
+	today := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+
+	err := service.SetMood(ctx, today, "happy")
+	require.NoError(t, err)
+	err = service.SetWeather(ctx, today, "sunny")
+	require.NoError(t, err)
+
+	err = service.SetLocation(ctx, today, "Office")
+	require.NoError(t, err)
+
+	dayCtx, err := dayCtxRepo.GetByDate(ctx, today)
+	require.NoError(t, err)
+	require.NotNil(t, dayCtx)
+	require.NotNil(t, dayCtx.Location, "Location should be set")
+	assert.Equal(t, "Office", *dayCtx.Location)
+	require.NotNil(t, dayCtx.Mood, "Mood should be preserved after setting location")
+	assert.Equal(t, "happy", *dayCtx.Mood)
+	require.NotNil(t, dayCtx.Weather, "Weather should be preserved after setting location")
+	assert.Equal(t, "sunny", *dayCtx.Weather)
+}
+
 func TestBujoService_MarkDone(t *testing.T) {
 	service, entryRepo, _ := setupBujoService(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Fix Header component to use passed `currentDate` prop instead of hardcoded `new Date()` for day context API calls
- Fix backend `SetLocation` to preserve existing mood/weather data (matching `SetMood`/`SetWeather` behavior)
- Add tests for both frontend and backend fixes

Fixes #407

## Test plan
- [x] Backend test verifies SetLocation preserves existing mood/weather
- [x] Frontend tests verify currentDate prop is used for all API calls (SetMood, SetWeather, SetLocation)
- [x] Frontend test verifies displayed date matches currentDate prop
- [x] All 764 frontend tests pass
- [x] All Go tests pass
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)