### PR TITLE
feat: track migration count for entries

### DIFF
--- a/frontend/src/lib/transforms.ts
+++ b/frontend/src/lib/transforms.ts
@@ -17,7 +17,7 @@ export function transformEntry(e: domain.Entry): Entry {
     parentId: e.ParentID ?? null,
     loggedDate,
     scheduledDate,
-    migrationCount: (e as { MigrationCount?: number }).MigrationCount,
+    migrationCount: e.MigrationCount,
   }
 }
 

--- a/frontend/src/wailsjs/go/models.ts
+++ b/frontend/src/wailsjs/go/models.ts
@@ -29,11 +29,12 @@ export namespace domain {
 	    ScheduledDate?: time.Time;
 	    CreatedAt: time.Time;
 	    SortOrder: number;
-	
+	    MigrationCount: number;
+
 	    static createFrom(source: any = {}) {
 	        return new Entry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.ID = source["ID"];
@@ -48,6 +49,7 @@ export namespace domain {
 	        this.ScheduledDate = this.convertValues(source["ScheduledDate"], time.Time);
 	        this.CreatedAt = this.convertValues(source["CreatedAt"], time.Time);
 	        this.SortOrder = source["SortOrder"];
+	        this.MigrationCount = source["MigrationCount"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/domain/attention.go
+++ b/internal/domain/attention.go
@@ -29,6 +29,7 @@ const (
 	attentionScoreUrgentKeyword = 20
 	attentionScoreQuestion      = 10
 	attentionScoreParentEvent   = 5
+	attentionScoreMigration     = 15
 	attentionAgingThresholdOld  = 7
 	attentionAgingThresholdNew  = 3
 )
@@ -72,6 +73,11 @@ func CalculateAttentionScore(entry Entry, now time.Time, parentType EntryType) A
 
 	if entry.Type == EntryTypeQuestion {
 		score += attentionScoreQuestion
+	}
+
+	if entry.MigrationCount > 0 {
+		score += entry.MigrationCount * attentionScoreMigration
+		indicators = append(indicators, AttentionMigrated)
 	}
 
 	if entry.ParentID != nil && parentType == EntryTypeEvent {

--- a/internal/domain/attention_test.go
+++ b/internal/domain/attention_test.go
@@ -184,6 +184,31 @@ func TestCalculateAttentionScore(t *testing.T) {
 		}
 	})
 
+	t.Run("adds 15 points per migration", func(t *testing.T) {
+		entry := newEntry()
+		entry.MigrationCount = 1
+		result := CalculateAttentionScore(entry, now, "")
+		if result.Score != 15 {
+			t.Errorf("expected score 15, got %d", result.Score)
+		}
+		assertContainsIndicator(t, result.Indicators, AttentionMigrated)
+	})
+
+	t.Run("adds 30 points for two migrations", func(t *testing.T) {
+		entry := newEntry()
+		entry.MigrationCount = 2
+		result := CalculateAttentionScore(entry, now, "")
+		if result.Score != 30 {
+			t.Errorf("expected score 30, got %d", result.Score)
+		}
+		assertContainsIndicator(t, result.Indicators, AttentionMigrated)
+	})
+
+	t.Run("no migration points for zero count", func(t *testing.T) {
+		result := CalculateAttentionScore(newEntry(), now, "")
+		assertNotContainsIndicator(t, result.Indicators, AttentionMigrated)
+	})
+
 	t.Run("combines multiple conditions", func(t *testing.T) {
 		fourDaysAgo := now.AddDate(0, 0, -4)
 		result := CalculateAttentionScore(

--- a/internal/domain/entry.go
+++ b/internal/domain/entry.go
@@ -104,6 +104,7 @@ type Entry struct {
 	ScheduledDate  *time.Time
 	CreatedAt      time.Time
 	SortOrder      int
+	MigrationCount int
 }
 
 func NewEntry(entryType EntryType, content string, scheduledDate *time.Time) Entry {

--- a/internal/repository/sqlite/migrations/000032_add_migration_count.down.sql
+++ b/internal/repository/sqlite/migrations/000032_add_migration_count.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries DROP COLUMN migration_count;

--- a/internal/repository/sqlite/migrations/000032_add_migration_count.up.sql
+++ b/internal/repository/sqlite/migrations/000032_add_migration_count.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries ADD COLUMN migration_count INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

Closes #449

- Add `MigrationCount` field to `domain.Entry` and persist it through SQLite (migration 000032), repository, service, Wails models, and frontend transforms
- Increment migration count each time an entry is migrated via `MigrateEntry`, carrying the count forward to child entries as well
- Award 15 attention score points per migration, adding `Migrated` indicator to the attention badge tooltip

## Test plan

- [x] Domain: 3 attention score tests verify migration scoring and indicator
- [x] Repository: 3 CRUD tests verify insert/retrieve, default-to-zero, and GetByDate
- [x] Service: 1 operations test verifies count increments 0→1→2 across multiple migrations
- [x] All pre-push checks pass (Go build/test/vet/lint, frontend lint/tsc/test/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)