### PR TITLE
feat: frontend tag display, autocomplete, and search integration

### DIFF
--- a/docs/plans/2026-02-07-frontend-tags-design.md
+++ b/docs/plans/2026-02-07-frontend-tags-design.md
@@ -1,0 +1,113 @@
+# Frontend Tag Display, Autocomplete & Management
+
+**Issue:** #458
+**Date:** 2026-02-07
+**Depends on:** PR #459 (backend tag infrastructure - merged)
+
+## Design Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Scope | All four capabilities in one PR |
+| Tag display | Inline in content - style `#tag` text with subtle color, no separate chips |
+| Tag filtering | Click tag navigates to SearchView with tag pre-filled |
+| Autocomplete trigger | After `#` + 1 character |
+| Tag management UI | Extend SearchView with tag browser panel |
+
+## Architecture
+
+Five implementation layers, built bottom-up:
+
+1. **Data plumbing** - Wire tag data from backend to frontend types
+2. **TagContent component** - Render inline styled tags in entry content
+3. **SearchView tag integration** - Tag filtering and tag browser panel
+4. **Editor autocomplete** - CodeMirror extension for `#tag` suggestions
+5. **Tag management** - Rename/delete from SearchView tag panel
+
+## Layer 1: Data Plumbing
+
+### `frontend/src/wailsjs/go/models.ts`
+Add `Tags: string[]` to `domain.Entry` class. Manual addition with comment noting next Wails regeneration will pick it up.
+
+### `frontend/src/types/bujo.ts`
+Add `tags?: string[]` to `Entry` interface. Optional because older entries may not have tags.
+
+### `frontend/src/lib/transforms.ts`
+Map `e.Tags` to `tags` in `transformEntry()`:
+```typescript
+tags: e.Tags || [],
+```
+
+### SearchView `SearchResult` type
+Add `tags?: string[]` and map from backend results.
+
+## Layer 2: TagContent Component
+
+Pure rendering component: `frontend/src/components/bujo/TagContent.tsx`
+
+Parses entry content string and renders `#tag` portions as styled clickable spans.
+
+```
+Input:  "Buy groceries #shopping #errands"
+Output: ["Buy groceries ", <span class="tag">#shopping</span>, " ", <span class="tag">#errands</span>]
+```
+
+- Regex: `#([a-zA-Z][a-zA-Z0-9-]*)` (matches backend)
+- Tag spans: subtle color differentiation, rounded background on hover, pointer cursor
+- Respects entry type styling (done = done color, cancelled = line-through)
+- `onTagClick(tagName)` callback prop for navigation
+- Used in both `EntryItem.tsx` (line 204) and `SearchView.tsx` (line 338)
+
+## Layer 3: SearchView Tag Extension
+
+### Tag filtering mode
+- New prop: `initialTagFilter?: string`
+- When present, calls `SearchByTags([tag])` instead of `Search(query)`
+- Shows "Filtered by #tag" indicator with clear button
+- Search input still visible for further refinement
+
+### Tag browser panel
+- Collapsible section below search input
+- Fetches all tags via `GetAllTags()`
+- Horizontal flex-wrap list of small pill elements
+- Each shows tag name + entry count
+- Click applies as filter
+- "..." menu on each pill for rename/delete
+
+### Navigation flow
+Click tag in EntryItem -> App navigates to SearchView with `initialTagFilter="tagname"` -> SearchView calls `SearchByTags(["tagname"])` -> results displayed
+
+## Layer 4: Editor Autocomplete
+
+Custom CodeMirror `CompletionSource` in `BujoEditor.tsx`:
+
+1. Watches for `#` followed by 1+ word characters
+2. Fetches suggestions from cached `GetAllTags()` call
+3. Shows completion dropdown with matching tags
+4. Replaces partial `#xxx` with `#selected-tag` on selection
+5. Escape dismisses
+
+## Layer 5: Tag Management (Deferred)
+
+Backend `RenameTag` and `DeleteTag` endpoints do not exist yet. Tag management (rename/delete) is deferred to a follow-up issue. The tag browser panel will show all tags with counts but without rename/delete actions for now.
+
+## New Files
+
+- `frontend/src/components/bujo/TagContent.tsx` - Inline tag rendering
+- `frontend/src/components/bujo/TagContent.test.tsx` - Tests
+- `frontend/src/components/bujo/TagPanel.tsx` - Tag browser/management panel
+- `frontend/src/components/bujo/TagPanel.test.tsx` - Tests
+- `frontend/src/lib/codemirror/tagAutocomplete.ts` - CodeMirror extension
+- `frontend/src/lib/codemirror/tagAutocomplete.test.ts` - Tests
+
+## Modified Files
+
+- `frontend/src/wailsjs/go/models.ts` - Add Tags field
+- `frontend/src/types/bujo.ts` - Add tags to Entry
+- `frontend/src/lib/transforms.ts` - Map tags in transform
+- `frontend/src/lib/transforms.test.ts` - Test tag mapping
+- `frontend/src/components/bujo/EntryItem.tsx` - Use TagContent
+- `frontend/src/components/bujo/SearchView.tsx` - Tag filtering + TagPanel
+- `frontend/src/components/bujo/SearchView.test.tsx` - Tests
+- `frontend/src/lib/codemirror/BujoEditor.tsx` - Add autocomplete extension
+- `frontend/src/App.tsx` - Pass initialTagFilter to SearchView

--- a/frontend/src/App.capture.test.tsx
+++ b/frontend/src/App.capture.test.tsx
@@ -36,6 +36,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.context.test.tsx
+++ b/frontend/src/App.context.test.tsx
@@ -43,6 +43,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.daynavigation.test.tsx
+++ b/frontend/src/App.daynavigation.test.tsx
@@ -43,6 +43,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.historyNavigation.test.tsx
+++ b/frontend/src/App.historyNavigation.test.tsx
@@ -39,6 +39,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.keyboard-shortcuts.test.tsx
+++ b/frontend/src/App.keyboard-shortcuts.test.tsx
@@ -41,6 +41,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.searchNavigation.test.tsx
+++ b/frontend/src/App.searchNavigation.test.tsx
@@ -38,6 +38,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,6 +69,7 @@ function App() {
   const [editModalEntry, setEditModalEntry] = useState<Entry | null>(null)
   const [deleteDialogEntry, setDeleteDialogEntry] = useState<Entry | null>(null)
   const [deleteHasChildren, setDeleteHasChildren] = useState(false)
+  const [searchTagFilter, setSearchTagFilter] = useState<string | null>(null)
   const [migrateModalEntry, setMigrateModalEntry] = useState<Entry | null>(null)
   const [moveToListEntry, setMoveToListEntry] = useState<Entry | null>(null)
   const [answerModalEntry, setAnswerModalEntry] = useState<Entry | null>(null)
@@ -264,6 +265,7 @@ function App() {
       })
     }
     setHighlightText(null)
+    if (newView !== 'search') setSearchTagFilter(null)
     setView(newView)
     setSelectedIndex(0)
   }, [view, clearHistory, pushHistory])
@@ -604,6 +606,11 @@ function App() {
     })
   }, [])
 
+  const handleTagClick = useCallback((tag: string) => {
+    setSearchTagFilter(tag)
+    handleViewChange('search')
+  }, [handleViewChange])
+
   const handleBack = useCallback(() => {
     const previousState = goBack()
     if (previousState && isValidView(previousState.view)) {
@@ -788,9 +795,11 @@ function App() {
           {view === 'search' && (
             <div className="max-w-3xl mx-auto">
               <SearchView
+                initialTagFilter={searchTagFilter ?? undefined}
                 onMigrate={handleSearchMigrate}
                 onNavigateToEntry={handleSearchNavigate}
                 onSelectEntry={handleSearchSelectEntry}
+                onTagClick={handleTagClick}
               />
             </div>
           )}

--- a/frontend/src/App.weekView.test.tsx
+++ b/frontend/src/App.weekView.test.tsx
@@ -33,6 +33,7 @@ vi.mock('./wailsjs/go/wails/App', () => ({
   SetWeather: vi.fn().mockResolvedValue(undefined),
   SetLocation: vi.fn().mockResolvedValue(undefined),
   GetLocationHistory: vi.fn().mockResolvedValue(['Home', 'Office']),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   OpenFileDialog: vi.fn().mockResolvedValue(''),
   ReadFile: vi.fn().mockResolvedValue(''),
   GetEditableDocument: vi.fn().mockResolvedValue(''),

--- a/frontend/src/components/bujo/EntryItem.core.test.tsx
+++ b/frontend/src/components/bujo/EntryItem.core.test.tsx
@@ -226,7 +226,7 @@ describe('EntryItem', () => {
 
     it('renders cancelled entry with strikethrough style', () => {
       render(<EntryItem entry={createTestEntry({ type: 'cancelled', content: 'Cancelled task' })} />)
-      const content = screen.getByText('Cancelled task')
+      const content = screen.getByText('Cancelled task').closest('.flex-1')
       expect(content).toHaveClass('line-through')
     })
 
@@ -474,9 +474,30 @@ describe('EntryItem', () => {
   describe('visual styling', () => {
     it('renders done entries with success color (not strikethrough)', () => {
       render(<EntryItem entry={createTestEntry({ type: 'done', content: 'Done task' })} />)
-      const content = screen.getByText('Done task')
+      const content = screen.getByText('Done task').closest('.flex-1')
       expect(content).toHaveClass('text-bujo-done')
       expect(content).not.toHaveClass('line-through')
+    })
+  })
+
+  describe('tag rendering', () => {
+    it('renders tags in content as styled spans', () => {
+      render(<EntryItem entry={createTestEntry({ content: 'Task #work' })} />)
+      const tag = screen.getByText('#work')
+      expect(tag).toHaveClass('tag')
+    })
+
+    it('calls onTagClick when a tag is clicked', () => {
+      const onTagClick = vi.fn()
+      render(
+        <EntryItem
+          entry={createTestEntry({ content: 'Task #work' })}
+          onTagClick={onTagClick}
+        />
+      )
+
+      fireEvent.click(screen.getByText('#work'))
+      expect(onTagClick).toHaveBeenCalledWith('work')
     })
   })
 

--- a/frontend/src/components/bujo/EntryItem.tsx
+++ b/frontend/src/components/bujo/EntryItem.tsx
@@ -4,6 +4,7 @@ import { EntrySymbol } from './EntrySymbol';
 import { EntryActionBar } from './EntryActions';
 import { cn } from '@/lib/utils';
 import { calculateMenuPosition } from '@/lib/menuPosition';
+import { TagContent } from './TagContent';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 
 interface EntryItemProps {
@@ -30,6 +31,7 @@ interface EntryItemProps {
   onCycleType?: () => void;
   onMoveToRoot?: () => void;
   onMoveToList?: () => void;
+  onTagClick?: (tag: string) => void;
 }
 
 const CONTEXT_MENU_ESTIMATED_SIZE = { width: 150, height: 300 };
@@ -71,6 +73,7 @@ export function EntryItem({
   onCycleType,
   onMoveToRoot,
   onMoveToList,
+  onTagClick,
 }: EntryItemProps) {
   const isToggleable = entry.type === 'task' || entry.type === 'done';
   const canChangeType = entry.type === 'task' || entry.type === 'note' || entry.type === 'event' || entry.type === 'question';
@@ -202,7 +205,7 @@ export function EntryItem({
 
       {/* Content */}
       <span className={cn('flex-1 text-sm', contentStyles[entry.type])}>
-        {entry.content}
+        <TagContent content={entry.content} onTagClick={onTagClick} />
       </span>
 
       {/* Hidden child count when collapsed */}

--- a/frontend/src/components/bujo/JournalView.test.tsx
+++ b/frontend/src/components/bujo/JournalView.test.tsx
@@ -8,6 +8,12 @@ vi.mock('@/hooks/useEditableDocument', () => ({
   useEditableDocument: (...args: unknown[]) => mockUseEditableDocument(...args),
 }))
 
+const mockGetAllTags = vi.fn().mockResolvedValue([])
+
+vi.mock('@/wailsjs/go/wails/App', () => ({
+  GetAllTags: (...args: unknown[]) => mockGetAllTags(...args),
+}))
+
 const createMockState = (overrides = {}) => ({
   document: '. Buy groceries\n- Meeting notes',
   originalDocument: '. Buy groceries\n- Meeting notes',
@@ -336,6 +342,29 @@ describe('JournalView', () => {
       expect(screen.getByText(/Indent/)).toBeInTheDocument()
       expect(screen.getByText(/Esc/)).toBeInTheDocument()
       expect(screen.getByText(/Unfocus/)).toBeInTheDocument()
+    })
+  })
+
+  describe('tag autocomplete', () => {
+    it('fetches tags on mount', async () => {
+      mockGetAllTags.mockResolvedValue(['work', 'personal'])
+
+      render(<JournalView date={testDate} />)
+
+      await waitFor(() => {
+        expect(mockGetAllTags).toHaveBeenCalled()
+      })
+    })
+
+    it('renders without error when GetAllTags fails', async () => {
+      mockGetAllTags.mockRejectedValue(new Error('network error'))
+
+      render(<JournalView date={testDate} />)
+
+      await waitFor(() => {
+        expect(mockGetAllTags).toHaveBeenCalled()
+      })
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/bujo/JournalView.tsx
+++ b/frontend/src/components/bujo/JournalView.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { useEditableDocument } from '@/hooks/useEditableDocument'
+import { GetAllTags } from '@/wailsjs/go/wails/App'
 import { BujoEditor } from '@/lib/codemirror/BujoEditor'
 import { scanForNewSpecialEntries, SpecialEntries } from '@/hooks/useSaveWithDialogs'
 import { MigrateBatchModal } from '@/components/bujo/MigrateBatchModal'
@@ -29,8 +30,13 @@ export function JournalView({ date, highlightText, onHighlightDone }: JournalVie
     discardDraft,
   } = useEditableDocument(date)
 
+  const [tags, setTags] = useState<string[]>([])
   const [saveError, setSaveError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    GetAllTags().then(t => setTags(t || [])).catch(() => {})
+  }, [])
 
   const [pendingSpecial, setPendingSpecial] = useState<SpecialEntries | null>(null)
   const [migrateDate, setMigrateDate] = useState<Date | null>(null)
@@ -180,6 +186,7 @@ export function JournalView({ date, highlightText, onHighlightDone }: JournalVie
             onEscape={handleEscape}
             highlightText={highlightText}
             onHighlightDone={onHighlightDone}
+            tags={tags}
           />
         </div>
       </div>

--- a/frontend/src/components/bujo/SearchView.core.test.tsx
+++ b/frontend/src/components/bujo/SearchView.core.test.tsx
@@ -5,6 +5,8 @@ import { SearchView } from './SearchView'
 
 vi.mock('@/wailsjs/go/wails/App', () => ({
   Search: vi.fn().mockResolvedValue([]),
+  SearchByTags: vi.fn().mockResolvedValue([]),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   GetEntry: vi.fn().mockResolvedValue(null),
   MarkEntryDone: vi.fn().mockResolvedValue(undefined),
   MarkEntryUndone: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/components/bujo/SearchView.features.test.tsx
+++ b/frontend/src/components/bujo/SearchView.features.test.tsx
@@ -5,6 +5,8 @@ import { SearchView } from './SearchView'
 
 vi.mock('@/wailsjs/go/wails/App', () => ({
   Search: vi.fn().mockResolvedValue([]),
+  SearchByTags: vi.fn().mockResolvedValue([]),
+  GetAllTags: vi.fn().mockResolvedValue([]),
   GetEntry: vi.fn().mockResolvedValue(null),
   GetEntryAncestors: vi.fn().mockResolvedValue([]),
   MarkEntryDone: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/components/bujo/SearchView.tags.test.tsx
+++ b/frontend/src/components/bujo/SearchView.tags.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchView } from './SearchView'
+
+vi.mock('@/wailsjs/go/wails/App', () => ({
+  Search: vi.fn().mockResolvedValue([]),
+  SearchByTags: vi.fn().mockResolvedValue([]),
+  GetAllTags: vi.fn().mockResolvedValue([]),
+  GetEntry: vi.fn().mockResolvedValue(null),
+  MarkEntryDone: vi.fn().mockResolvedValue(undefined),
+  MarkEntryUndone: vi.fn().mockResolvedValue(undefined),
+  CancelEntry: vi.fn().mockResolvedValue(undefined),
+  UncancelEntry: vi.fn().mockResolvedValue(undefined),
+  EditEntry: vi.fn().mockResolvedValue(undefined),
+  DeleteEntry: vi.fn().mockResolvedValue(undefined),
+  MigrateEntry: vi.fn().mockResolvedValue(1),
+  CyclePriority: vi.fn().mockResolvedValue(undefined),
+  RetypeEntry: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { Search, SearchByTags, GetAllTags } from '@/wailsjs/go/wails/App'
+
+const createMockEntry = (overrides: Partial<{ ID: number; Content: string; Type: string; CreatedAt: string; ParentID: number | null }>) => ({
+  ID: 1,
+  EntityID: 'test-entity',
+  Type: 'task',
+  Content: 'Test content',
+  Priority: 'none',
+  ParentID: null,
+  Depth: 0,
+  CreatedAt: '2024-01-15T10:00:00Z',
+  convertValues: vi.fn(),
+  ...overrides,
+})
+
+describe('SearchView - Tag Content Display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders tags in search results as styled spans', async () => {
+    vi.mocked(Search).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Buy groceries #shopping', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView />)
+
+    const input = screen.getByPlaceholderText(/search entries/i)
+    await user.type(input, 'groceries')
+
+    await waitFor(() => {
+      const tag = screen.getByText('#shopping')
+      expect(tag).toHaveClass('tag')
+    })
+  })
+})
+
+describe('SearchView - Tag Filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls SearchByTags when initialTagFilter is provided', async () => {
+    vi.mocked(SearchByTags).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Task #work', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    render(<SearchView initialTagFilter="work" />)
+
+    await waitFor(() => {
+      expect(SearchByTags).toHaveBeenCalledWith(['work'])
+    })
+  })
+
+  it('shows filtered-by indicator when tag filter is active', async () => {
+    vi.mocked(SearchByTags).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Task #work', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    render(<SearchView initialTagFilter="work" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('#work')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it('clears tag filter when clear button is clicked', async () => {
+    vi.mocked(SearchByTags).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Task #work', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView initialTagFilter="work" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('displays results from SearchByTags', async () => {
+    vi.mocked(SearchByTags).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Buy milk #shopping', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+      createMockEntry({ ID: 2, Content: 'Buy eggs #shopping', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    render(<SearchView initialTagFilter="shopping" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Buy milk')).toBeInTheDocument()
+      expect(screen.getByText('Buy eggs')).toBeInTheDocument()
+    })
+  })
+
+  it('does not call Search when initialTagFilter is provided', async () => {
+    vi.mocked(SearchByTags).mockResolvedValue([])
+
+    render(<SearchView initialTagFilter="work" />)
+
+    await waitFor(() => {
+      expect(SearchByTags).toHaveBeenCalled()
+    })
+    expect(Search).not.toHaveBeenCalled()
+  })
+})
+
+describe('SearchView - Tag Panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches and displays all tags', async () => {
+    vi.mocked(GetAllTags).mockResolvedValue(['work', 'personal', 'urgent'] as never)
+
+    render(<SearchView />)
+
+    await waitFor(() => {
+      expect(screen.getByText('#work')).toBeInTheDocument()
+      expect(screen.getByText('#personal')).toBeInTheDocument()
+      expect(screen.getByText('#urgent')).toBeInTheDocument()
+    })
+  })
+
+  it('filters by tag when clicking a tag pill', async () => {
+    vi.mocked(GetAllTags).mockResolvedValue(['work', 'personal'] as never)
+    vi.mocked(SearchByTags).mockResolvedValue([
+      createMockEntry({ ID: 1, Content: 'Task #work', Type: 'task', CreatedAt: '2024-01-15T10:00:00Z' }),
+    ] as never)
+
+    const user = userEvent.setup()
+    render(<SearchView />)
+
+    await waitFor(() => {
+      expect(screen.getByText('#work')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('#work'))
+
+    await waitFor(() => {
+      expect(SearchByTags).toHaveBeenCalledWith(['work'])
+    })
+  })
+
+  it('does not render tag panel when no tags exist', async () => {
+    vi.mocked(GetAllTags).mockResolvedValue([] as never)
+
+    render(<SearchView />)
+
+    await waitFor(() => {
+      expect(GetAllTags).toHaveBeenCalled()
+    })
+    expect(screen.queryByTestId('tag-panel')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/bujo/TagContent.test.tsx
+++ b/frontend/src/components/bujo/TagContent.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TagContent } from './TagContent'
+
+describe('TagContent', () => {
+  describe('rendering plain content', () => {
+    it('renders content without tags as plain text', () => {
+      render(<TagContent content="Buy groceries" />)
+      expect(screen.getByText('Buy groceries')).toBeInTheDocument()
+    })
+
+    it('renders empty content without crashing', () => {
+      const { container } = render(<TagContent content="" />)
+      expect(container.querySelector('span')).toBeInTheDocument()
+    })
+  })
+
+  describe('rendering tags', () => {
+    it('renders tag with # prefix as styled span', () => {
+      render(<TagContent content="Buy groceries #shopping" />)
+      expect(screen.getByText('#shopping')).toBeInTheDocument()
+      expect(screen.getByText('Buy groceries')).toBeInTheDocument()
+    })
+
+    it('renders multiple tags', () => {
+      render(<TagContent content="Task #work #urgent" />)
+      expect(screen.getByText('#work')).toBeInTheDocument()
+      expect(screen.getByText('#urgent')).toBeInTheDocument()
+    })
+
+    it('applies tag styling class to tag spans', () => {
+      render(<TagContent content="Task #work" />)
+      const tag = screen.getByText('#work')
+      expect(tag.tagName).toBe('SPAN')
+      expect(tag).toHaveClass('tag')
+    })
+
+    it('handles tag with hyphens', () => {
+      render(<TagContent content="Note #my-project" />)
+      expect(screen.getByText('#my-project')).toBeInTheDocument()
+    })
+
+    it('does not match hash followed by number', () => {
+      render(<TagContent content="Issue #123" />)
+      expect(screen.getByText('Issue #123')).toBeInTheDocument()
+    })
+
+    it('handles tag at start of content', () => {
+      render(<TagContent content="#important Buy milk" />)
+      expect(screen.getByText('#important')).toBeInTheDocument()
+      expect(screen.getByText('Buy milk')).toBeInTheDocument()
+    })
+
+    it('handles content that is only a tag', () => {
+      render(<TagContent content="#solo" />)
+      expect(screen.getByText('#solo')).toBeInTheDocument()
+    })
+  })
+
+  describe('tag click handling', () => {
+    it('calls onTagClick with tag name when tag is clicked', async () => {
+      const user = userEvent.setup()
+      const onTagClick = vi.fn()
+      render(<TagContent content="Task #work" onTagClick={onTagClick} />)
+
+      await user.click(screen.getByText('#work'))
+
+      expect(onTagClick).toHaveBeenCalledWith('work')
+      expect(onTagClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes correct tag name for each tag clicked', async () => {
+      const user = userEvent.setup()
+      const onTagClick = vi.fn()
+      render(<TagContent content="Task #work #urgent" onTagClick={onTagClick} />)
+
+      await user.click(screen.getByText('#urgent'))
+
+      expect(onTagClick).toHaveBeenCalledWith('urgent')
+    })
+
+    it('does not crash when onTagClick is not provided', async () => {
+      const user = userEvent.setup()
+      render(<TagContent content="Task #work" />)
+
+      await user.click(screen.getByText('#work'))
+      // Should not throw
+    })
+
+    it('applies cursor-pointer class when onTagClick is provided', () => {
+      const onTagClick = vi.fn()
+      render(<TagContent content="Task #work" onTagClick={onTagClick} />)
+      const tag = screen.getByText('#work')
+      expect(tag).toHaveClass('cursor-pointer')
+    })
+  })
+})

--- a/frontend/src/components/bujo/TagContent.tsx
+++ b/frontend/src/components/bujo/TagContent.tsx
@@ -1,0 +1,43 @@
+const TAG_REGEX = /#([a-zA-Z][a-zA-Z0-9-]*)/g
+
+interface TagContentProps {
+  content: string
+  onTagClick?: (tag: string) => void
+}
+
+export function TagContent({ content, onTagClick }: TagContentProps) {
+  const parts: (string | { tag: string })[] = []
+  let lastIndex = 0
+
+  for (const match of content.matchAll(TAG_REGEX)) {
+    const before = content.slice(lastIndex, match.index)
+    if (before) parts.push(before)
+    parts.push({ tag: match[1] })
+    lastIndex = match.index + match[0].length
+  }
+
+  const after = content.slice(lastIndex)
+  if (after) parts.push(after)
+
+  if (parts.length === 0) {
+    return <span />
+  }
+
+  return (
+    <span>
+      {parts.map((part, i) =>
+        typeof part === 'string' ? (
+          <span key={i}>{part}</span>
+        ) : (
+          <span
+            key={i}
+            className={`tag${onTagClick ? ' cursor-pointer' : ''}`}
+            onClick={onTagClick ? () => onTagClick(part.tag) : undefined}
+          >
+            #{part.tag}
+          </span>
+        ),
+      )}
+    </span>
+  )
+}

--- a/frontend/src/lib/codemirror/BujoEditor.test.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.test.tsx
@@ -123,6 +123,43 @@ describe('BujoEditor', () => {
     })
   })
 
+  describe('tag autocomplete', () => {
+    it('accepts tags prop without crashing', () => {
+      expect(() => {
+        render(
+          <BujoEditor
+            value=". Task with #wo"
+            onChange={() => {}}
+            tags={['work', 'workout']}
+          />
+        )
+      }).not.toThrow()
+    })
+
+    it('renders normally when tags is empty', () => {
+      render(
+        <BujoEditor
+          value=". Task"
+          onChange={() => {}}
+          tags={[]}
+        />
+      )
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    it('renders normally when tags is undefined', () => {
+      render(
+        <BujoEditor
+          value=". Task"
+          onChange={() => {}}
+        />
+      )
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+  })
+
   describe('visual extensions', () => {
     it('displays priority badges for priority markers', () => {
       render(

--- a/frontend/src/lib/codemirror/tagAutocomplete.test.ts
+++ b/frontend/src/lib/codemirror/tagAutocomplete.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { EditorState } from '@codemirror/state'
+import { CompletionContext } from '@codemirror/autocomplete'
+import { tagCompletionSource, tagAutocomplete } from './tagAutocomplete'
+
+describe('tagCompletionSource', () => {
+  function createContext(doc: string, pos: number): CompletionContext {
+    const state = EditorState.create({ doc })
+    return new CompletionContext(state, pos, false)
+  }
+
+  it('returns null when cursor is not after a tag', () => {
+    const source = tagCompletionSource(['work', 'personal'])
+    const result = source(createContext('hello world', 5))
+    expect(result).toBeNull()
+  })
+
+  it('returns null when only # is typed without letters', () => {
+    const source = tagCompletionSource(['work', 'personal'])
+    const result = source(createContext('hello #', 7))
+    expect(result).toBeNull()
+  })
+
+  it('returns matching tags when # followed by text', () => {
+    const source = tagCompletionSource(['work', 'weekend', 'personal'])
+    const result = source(createContext('task #we', 8))
+    expect(result).not.toBeNull()
+    expect(result!.from).toBe(5)
+    expect(result!.options).toHaveLength(1)
+    expect(result!.options[0].label).toBe('#weekend')
+  })
+
+  it('returns multiple matching tags for shared prefix', () => {
+    const source = tagCompletionSource(['work', 'workout', 'personal'])
+    const result = source(createContext('task #wo', 8))
+    expect(result).not.toBeNull()
+    expect(result!.options).toHaveLength(2)
+    expect(result!.options.map(o => o.label)).toContain('#work')
+    expect(result!.options.map(o => o.label)).toContain('#workout')
+  })
+
+  it('returns all tags when single letter matches all', () => {
+    const source = tagCompletionSource(['work', 'weekend'])
+    const result = source(createContext('#w', 2))
+    expect(result!.options).toHaveLength(2)
+  })
+
+  it('returns null when no tags match', () => {
+    const source = tagCompletionSource(['work', 'personal'])
+    const result = source(createContext('#z', 2))
+    expect(result).toBeNull()
+  })
+
+  it('matches case-insensitively', () => {
+    const source = tagCompletionSource(['Work', 'personal'])
+    const result = source(createContext('#wo', 3))
+    expect(result!.options).toHaveLength(1)
+    expect(result!.options[0].label).toBe('#Work')
+  })
+
+  it('returns null for empty tag list', () => {
+    const source = tagCompletionSource([])
+    const result = source(createContext('#w', 2))
+    expect(result).toBeNull()
+  })
+
+  it('handles tag with hyphens', () => {
+    const source = tagCompletionSource(['work-life', 'work'])
+    const result = source(createContext('#work-l', 7))
+    expect(result!.options).toHaveLength(1)
+    expect(result!.options[0].label).toBe('#work-life')
+  })
+})
+
+describe('tagAutocomplete', () => {
+  it('returns a valid CodeMirror extension', () => {
+    const extension = tagAutocomplete(['work'])
+    expect(extension).toBeDefined()
+  })
+
+  it('can be used to create an EditorState', () => {
+    const state = EditorState.create({
+      doc: 'test #w',
+      extensions: [tagAutocomplete(['work'])],
+    })
+    expect(state.doc.toString()).toBe('test #w')
+  })
+})

--- a/frontend/src/lib/codemirror/tagAutocomplete.ts
+++ b/frontend/src/lib/codemirror/tagAutocomplete.ts
@@ -1,0 +1,28 @@
+import { autocompletion, CompletionContext, CompletionResult } from '@codemirror/autocomplete'
+import { Extension } from '@codemirror/state'
+
+export function tagCompletionSource(tags: string[]) {
+  return (context: CompletionContext): CompletionResult | null => {
+    const word = context.matchBefore(/#[a-zA-Z][a-zA-Z0-9-]*/)
+    if (!word) return null
+
+    const partial = word.text.slice(1)
+    const filtered = tags.filter(t => t.toLowerCase().startsWith(partial.toLowerCase()))
+
+    if (filtered.length === 0) return null
+
+    return {
+      from: word.from,
+      options: filtered.map(tag => ({
+        label: `#${tag}`,
+        type: 'keyword',
+      })),
+    }
+  }
+}
+
+export function tagAutocomplete(tags: string[]): Extension {
+  return autocompletion({
+    override: [tagCompletionSource(tags)],
+  })
+}

--- a/frontend/src/lib/transforms.test.ts
+++ b/frontend/src/lib/transforms.test.ts
@@ -30,6 +30,7 @@ describe('transformEntry', () => {
       priority: 'high',
       parentId: null,
       loggedDate: '2026-01-15T10:00:00Z',
+      tags: [],
     })
   })
 
@@ -110,6 +111,54 @@ describe('transformEntry', () => {
     const result = transformEntry(input)
 
     expect(result.loggedDate).toBe('2026-01-18T10:00:00Z')
+  })
+
+  it('maps Tags field from backend entry', () => {
+    const input = {
+      ID: 7,
+      Type: 'Task',
+      Content: 'Buy groceries #shopping #errands',
+      Priority: 'None',
+      ParentID: undefined,
+      CreatedAt: '2026-01-15T10:00:00Z',
+      Tags: ['shopping', 'errands'],
+    } as unknown as domain.Entry
+
+    const result = transformEntry(input)
+
+    expect(result.tags).toEqual(['shopping', 'errands'])
+  })
+
+  it('defaults to empty array when Tags is undefined', () => {
+    const input = {
+      ID: 8,
+      Type: 'Note',
+      Content: 'No tags here',
+      Priority: '',
+      ParentID: undefined,
+      CreatedAt: '2026-01-15T10:00:00Z',
+      Tags: undefined,
+    } as unknown as domain.Entry
+
+    const result = transformEntry(input)
+
+    expect(result.tags).toEqual([])
+  })
+
+  it('defaults to empty array when Tags is null', () => {
+    const input = {
+      ID: 9,
+      Type: 'Note',
+      Content: 'Null tags',
+      Priority: '',
+      ParentID: undefined,
+      CreatedAt: '2026-01-15T10:00:00Z',
+      Tags: null,
+    } as unknown as domain.Entry
+
+    const result = transformEntry(input)
+
+    expect(result.tags).toEqual([])
   })
 })
 

--- a/frontend/src/lib/transforms.ts
+++ b/frontend/src/lib/transforms.ts
@@ -18,6 +18,7 @@ export function transformEntry(e: domain.Entry): Entry {
     loggedDate,
     scheduledDate,
     migrationCount: e.MigrationCount,
+    tags: e.Tags || [],
   }
 }
 

--- a/frontend/src/types/bujo.ts
+++ b/frontend/src/types/bujo.ts
@@ -13,6 +13,7 @@ export interface Entry {
   loggedDate: string;
   scheduledDate?: string;
   migrationCount?: number;
+  tags?: string[];
   children?: Entry[];
   collapsed?: boolean;
 }

--- a/frontend/src/wailsjs/go/models.ts
+++ b/frontend/src/wailsjs/go/models.ts
@@ -30,6 +30,7 @@ export namespace domain {
 	    CreatedAt: time.Time;
 	    SortOrder: number;
 	    MigrationCount: number;
+	    Tags: string[];
 
 	    static createFrom(source: any = {}) {
 	        return new Entry(source);
@@ -50,6 +51,7 @@ export namespace domain {
 	        this.CreatedAt = this.convertValues(source["CreatedAt"], time.Time);
 	        this.SortOrder = source["SortOrder"];
 	        this.MigrationCount = source["MigrationCount"];
+	        this.Tags = source["Tags"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/src/wailsjs/go/wails/App.d.ts
+++ b/frontend/src/wailsjs/go/wails/App.d.ts
@@ -58,6 +58,8 @@ export function GetEntryAncestors(arg1:number):Promise<Array<domain.Entry>>;
 
 export function GetEntryContext(arg1:number):Promise<Array<domain.Entry>>;
 
+export function GetAllTags():Promise<Array<string>>;
+
 export function GetGoals(arg1:time.Time):Promise<Array<domain.Goal>>;
 
 export function GetHabits(arg1:number):Promise<service.TrackerStatus>;
@@ -141,6 +143,8 @@ export function ResolveDate(arg1:string):Promise<wails.ResolvedDate>;
 export function RetypeEntry(arg1:number,arg2:string):Promise<void>;
 
 export function Search(arg1:string):Promise<Array<domain.Entry>>;
+
+export function SearchByTags(arg1:Array<string>):Promise<Array<domain.Entry>>;
 
 export function SetHabitGoal(arg1:number,arg2:number):Promise<void>;
 

--- a/frontend/src/wailsjs/go/wails/App.js
+++ b/frontend/src/wailsjs/go/wails/App.js
@@ -106,6 +106,10 @@ export function GetEntryContext(arg1) {
   return window['go']['wails']['App']['GetEntryContext'](arg1);
 }
 
+export function GetAllTags() {
+  return window['go']['wails']['App']['GetAllTags']();
+}
+
 export function GetGoals(arg1) {
   return window['go']['wails']['App']['GetGoals'](arg1);
 }
@@ -272,6 +276,10 @@ export function RetypeEntry(arg1, arg2) {
 
 export function Search(arg1) {
   return window['go']['wails']['App']['Search'](arg1);
+}
+
+export function SearchByTags(arg1) {
+  return window['go']['wails']['App']['SearchByTags'](arg1);
 }
 
 export function SetHabitGoal(arg1, arg2) {


### PR DESCRIPTION
## Summary

Closes #458

Implements four frontend tag capabilities building on the backend tag infrastructure from PR #459:

- **Tag display**: New `TagContent` component renders `#tag` portions of entry content with subtle colored inline styling
- **Clickable tag filtering**: Click any styled `#tag` in entries to navigate to SearchView with that tag pre-filtered via `SearchByTags`
- **Editor autocomplete**: CodeMirror `CompletionSource` extension suggests existing tags after typing `#` + 1 character in the journal editor
- **Tag browser panel**: Collapsible section in SearchView showing all tags with entry counts; click to filter

Layer 5 (tag management: rename/delete) is deferred to a follow-up issue as no backend endpoints exist yet.

### New files
- `TagContent.tsx` / `.test.tsx` - Inline tag rendering component
- `tagAutocomplete.ts` / `.test.ts` - CodeMirror completion extension
- `SearchView.tags.test.tsx` - Tag-specific SearchView tests
- Design doc: `docs/plans/2026-02-07-frontend-tags-design.md`

### Modified files
- `EntryItem.tsx` - Uses TagContent for content rendering
- `SearchView.tsx` - Tag filtering mode + tag browser panel
- `BujoEditor.tsx` - Compartment-based dynamic tag autocomplete
- `JournalView.tsx` - Fetches tags via `GetAllTags()` and passes to editor
- `App.tsx` - Routes tag clicks to SearchView with `initialTagFilter`
- Types/transforms/Wails bindings updated for `tags` field
- 7 App-level test files updated with `GetAllTags` mock

## Test plan

- [x] 1025 tests pass (78 test files), 0 failures
- [x] TypeScript compiles with no errors
- [x] Pre-push checks pass (lint, tsc, test, build, audit)
- [ ] Manual: Type `#` in editor and verify autocomplete dropdown appears
- [ ] Manual: Click a `#tag` in an entry and verify SearchView opens with that tag filtered
- [ ] Manual: Expand tag browser panel in SearchView and verify tags with counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)