### PR TITLE
fix: prevent overlapping labels on habit tracker

### DIFF
--- a/frontend/src/components/bujo/HabitTrackerView.goals.test.tsx
+++ b/frontend/src/components/bujo/HabitTrackerView.goals.test.tsx
@@ -282,6 +282,49 @@ describe('HabitTracker - Monthly Goal Display', () => {
   })
 })
 
+describe('HabitTracker - Stats Overflow Containment', () => {
+  it('contains habit name column with overflow-hidden to prevent label overlap', () => {
+    const habit = createTestHabit({
+      name: 'Exercise',
+      goal: 3,
+      goalPerWeek: 5,
+      weeklyProgress: 60,
+      goalPerMonth: 20,
+      monthlyProgress: 45,
+    })
+    render(<HabitTracker habits={[habit]} />)
+
+    const nameElement = screen.getByText('Exercise')
+    const nameColumn = nameElement.closest('.flex-shrink-0')
+    expect(nameColumn).toHaveClass('overflow-hidden')
+  })
+
+  it('wraps stats row when multiple goals are displayed', () => {
+    const habit = createTestHabit({
+      name: 'Exercise',
+      goal: 3,
+      goalPerWeek: 5,
+      weeklyProgress: 60,
+      goalPerMonth: 20,
+      monthlyProgress: 45,
+    })
+    render(<HabitTracker habits={[habit]} />)
+
+    const completionText = screen.getByText(/45%/)
+    const statsRow = completionText.closest('.flex.items-center.gap-1\\.5')
+    expect(statsRow).toHaveClass('flex-wrap')
+  })
+
+  it('uses wider name column to prevent overlap with calendar', () => {
+    const habit = createTestHabit({ name: 'Exercise' })
+    render(<HabitTracker habits={[habit]} />)
+
+    const nameElement = screen.getByText('Exercise')
+    const nameColumn = nameElement.closest('.flex-shrink-0')
+    expect(nameColumn).toHaveClass('w-40')
+  })
+})
+
 describe('HabitTracker - Goal Type Selection', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/components/bujo/HabitTrackerView.tsx
+++ b/frontend/src/components/bujo/HabitTrackerView.tsx
@@ -141,7 +141,7 @@ function HabitRow({
   return (
     <div className="flex items-center gap-4 py-3 px-4 rounded-lg bg-card hover:bg-secondary/30 transition-colors group">
       {/* Habit name and streak */}
-      <div className="flex-shrink-0 min-w-0 w-32">
+      <div className="flex-shrink-0 min-w-0 w-40 overflow-hidden">
         <div className="flex items-center gap-2">
           <span className="font-medium text-sm truncate">{habit.name}</span>
           {habit.streak > 0 && (
@@ -154,7 +154,7 @@ function HabitRow({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+        <div className="flex items-center gap-1.5 flex-wrap text-xs text-muted-foreground mt-0.5">
           <span>{habit.completionRate}% completion</span>
           {habit.goal && (
             <span
@@ -506,7 +506,7 @@ export function HabitTracker({ habits, onHabitChanged, period, onPeriodChange, a
       {/* Shared day header for week view */}
       {currentPeriod === 'week' && habits.length > 0 && (
         <div className="flex items-center gap-4 px-4">
-          <div className="flex-shrink-0 w-32" />
+          <div className="flex-shrink-0 w-40" />
           <div className="flex-1">
             <div className="grid grid-cols-7 gap-px mb-1">
               {getWeekDates(effectiveAnchor).map((day, i) => (


### PR DESCRIPTION
## Summary
- Widen habit name+stats column from `w-32` (128px) to `w-40` (160px) to give more room for goal indicators
- Add `overflow-hidden` to the name column to hard-contain any content that still exceeds the width
- Add `flex-wrap` to the stats row so daily/weekly/monthly goal indicators wrap gracefully instead of overflowing into the calendar grid
- Update the shared week-view header spacer to match the new `w-40` width

Fixes #461

## Test plan
- [x] Added 3 new tests in `HabitTrackerView.goals.test.tsx` verifying overflow containment, flex-wrap, and column width
- [x] All 1028 frontend tests pass (3 skipped)
- [x] TypeScript compiles clean
- [x] Pre-push lint, tsc, test, build, and audit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)