### PR TITLE
fix: resolve UI layout bugs in settings, search, and find/replace (#465, #466, #467)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -793,7 +793,7 @@ function App() {
           )}
 
           {view === 'search' && (
-            <div className="max-w-3xl mx-auto">
+            <div className="max-w-4xl mx-auto">
               <SearchView
                 initialTagFilter={searchTagFilter ?? undefined}
                 onMigrate={handleSearchMigrate}
@@ -817,7 +817,7 @@ function App() {
           )}
 
           {view === 'settings' && (
-            <div className="max-w-2xl mx-auto">
+            <div className="max-w-4xl mx-auto">
               <SettingsView />
             </div>
           )}

--- a/frontend/src/components/bujo/SettingsView.test.tsx
+++ b/frontend/src/components/bujo/SettingsView.test.tsx
@@ -175,6 +175,29 @@ describe('SettingsView', () => {
     expect(parsed.defaultView).toBe('search')
   })
 
+  it('setting rows wrap content to prevent overlap', () => {
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+
+    const themeRow = screen.getByText('Theme').closest('div[class*="flex"]')
+    expect(themeRow?.className).toContain('flex-wrap')
+    expect(themeRow?.className).toContain('gap-')
+  })
+
+  it('setting rows have minimum width for labels', () => {
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+
+    const themeLabel = screen.getByText('Theme').parentElement
+    expect(themeLabel?.className).toContain('min-w-')
+  })
+
   it('displays backend version from API', async () => {
     vi.mocked(WailsApp.GetVersion).mockResolvedValue('v0.1.0-nightly+85d8787')
 

--- a/frontend/src/components/bujo/SettingsView.tsx
+++ b/frontend/src/components/bujo/SettingsView.tsx
@@ -105,8 +105,8 @@ interface SettingRowProps {
 
 function SettingRow({ label, description, children }: SettingRowProps) {
   return (
-    <div className="flex items-center justify-between">
-      <div>
+    <div className="flex items-center justify-between flex-wrap gap-2">
+      <div className="min-w-0">
         <p className="text-sm font-medium">{label}</p>
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>

--- a/frontend/src/lib/codemirror/bujoTheme.test.ts
+++ b/frontend/src/lib/codemirror/bujoTheme.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { bujoTheme } from './bujoTheme'
+import { bujoTheme, bujoThemeStyles } from './bujoTheme'
 
 describe('bujoTheme', () => {
   it('exports a valid CodeMirror extension', () => {
     expect(bujoTheme).toBeDefined()
     expect(Array.isArray(bujoTheme) || typeof bujoTheme === 'object').toBe(true)
+  })
+
+  it('search buttons use primary styling for readability', () => {
+    const buttonStyles = bujoThemeStyles['& .cm-search button']
+    expect(buttonStyles.backgroundColor).toBe('hsl(var(--primary))')
+    expect(buttonStyles.color).toBe('hsl(var(--primary-foreground))')
+  })
+
+  it('search buttons have adequate padding for readability', () => {
+    const buttonStyles = bujoThemeStyles['& .cm-search button']
+    expect(buttonStyles.padding).toBe('4px 12px')
   })
 })

--- a/frontend/src/lib/codemirror/bujoTheme.ts
+++ b/frontend/src/lib/codemirror/bujoTheme.ts
@@ -1,6 +1,6 @@
 import { EditorView } from '@codemirror/view'
 
-export const bujoTheme = EditorView.theme({
+export const bujoThemeStyles: Record<string, Record<string, string>> = {
   '&': {
     backgroundColor: 'hsl(var(--background))',
     color: 'hsl(var(--foreground))',
@@ -160,16 +160,17 @@ export const bujoTheme = EditorView.theme({
     boxShadow: '0 0 0 1px hsl(var(--primary) / 0.3)',
   },
   '& .cm-search button': {
-    backgroundColor: 'hsl(var(--secondary))',
-    color: 'hsl(var(--secondary-foreground))',
-    border: '1px solid hsl(var(--border))',
+    backgroundColor: 'hsl(var(--primary))',
+    color: 'hsl(var(--primary-foreground))',
+    border: '1px solid hsl(var(--primary))',
     borderRadius: '4px',
-    padding: '2px 8px',
+    padding: '4px 12px',
     fontSize: '12px',
+    fontWeight: '500',
     cursor: 'pointer',
   },
   '& .cm-search button:hover': {
-    backgroundColor: 'hsl(var(--secondary) / 0.8)',
+    backgroundColor: 'hsl(var(--primary) / 0.85)',
   },
   '& .cm-search label': {
     fontSize: '12px',
@@ -182,4 +183,6 @@ export const bujoTheme = EditorView.theme({
   '& .cm-searchMatch-selected': {
     backgroundColor: 'hsl(var(--primary) / 0.4)',
   },
-})
+}
+
+export const bujoTheme = EditorView.theme(bujoThemeStyles)


### PR DESCRIPTION
## Summary

- **#465 Settings overlapping labels**: Widened settings container from `max-w-2xl` to `max-w-4xl` and added `flex-wrap gap-2` to `SettingRow` to prevent label/control overlap
- **#466 Search bar too small**: Widened search container from `max-w-3xl` to `max-w-4xl` to use more screen width
- **#467 Unreadable find & replace buttons**: Changed CodeMirror search buttons from `secondary` to `primary` color scheme with increased padding (`4px 12px`) and font weight for better readability

## Test plan

- [x] All 1032 existing tests pass
- [x] 2 new tests for SettingsView flex-wrap and min-width behavior
- [x] 2 new tests for bujoTheme button primary styling and padding
- [ ] Visual verification: Open settings page and confirm labels don't overlap
- [ ] Visual verification: Open search page and confirm input uses more width
- [ ] Visual verification: Open journal, press Cmd+F, confirm button labels are readable

Closes #465, closes #466, closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)