### PR TITLE
fix: handle NULL nullable fields in decisions query (#462)

### DIFF
--- a/internal/repository/sqlite/insights_repository.go
+++ b/internal/repository/sqlite/insights_repository.go
@@ -587,9 +587,9 @@ func (r *InsightsRepository) GetDecisionsWithInitiatives(ctx context.Context) ([
 		SELECT
 			d.id,
 			d.decision_text,
-			d.rationale,
-			d.participants,
-			d.expected_outcomes,
+			COALESCE(d.rationale, ''),
+			COALESCE(d.participants, ''),
+			COALESCE(d.expected_outcomes, ''),
 			d.decision_date,
 			d.summary_id,
 			d.created_at,

--- a/internal/repository/sqlite/insights_repository_test.go
+++ b/internal/repository/sqlite/insights_repository_test.go
@@ -512,6 +512,27 @@ func TestInsightsRepository_GetDecisionsWithInitiatives(t *testing.T) {
 		assert.Equal(t, "GenAI Integration", decisions[1].Initiatives)
 	})
 
+	t.Run("handles decisions with NULL nullable fields", func(t *testing.T) {
+		db := setupInsightsTestDB(t)
+		repo := NewInsightsRepository(db)
+
+		_, err := db.Exec(`
+			INSERT INTO decisions (decision_text, rationale, participants, expected_outcomes, decision_date, summary_id, created_at)
+			VALUES ('Minimal decision', NULL, NULL, NULL, '2026-02-01', NULL, '2026-02-01 09:00:00')
+		`)
+		require.NoError(t, err)
+
+		decisions, err := repo.GetDecisionsWithInitiatives(ctx)
+		require.NoError(t, err)
+		require.Len(t, decisions, 3)
+
+		assert.Equal(t, "Minimal decision", decisions[0].DecisionText)
+		assert.Empty(t, decisions[0].Rationale)
+		assert.Empty(t, decisions[0].Participants)
+		assert.Empty(t, decisions[0].ExpectedOutcomes)
+		assert.Empty(t, decisions[0].Initiatives)
+	})
+
 	t.Run("returns empty slice when db is nil", func(t *testing.T) {
 		repo := NewInsightsRepository(nil)
 


### PR DESCRIPTION
## Summary

- `GetDecisionsWithInitiatives` scanned SQL NULL values (`rationale`, `participants`, `expected_outcomes`) into Go `string` fields, causing a scan error that made the decision log return empty on the insights page
- Added `COALESCE(column, '')` for the three nullable columns, consistent with how `getInitiativeDecisions` already handles them
- Added test case exercising the NULL path that was previously untested

Closes #462

## Test plan

- [x] New test case `handles decisions with NULL nullable fields` passes
- [x] All existing insights repository tests pass (32 tests)
- [x] Full Go test suite passes
- [ ] Manual verification: open insights page and confirm decisions are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)