### PR TITLE
feat: settings page link improvements (#361)

### DIFF
--- a/frontend/src/components/bujo/SettingsView.test.tsx
+++ b/frontend/src/components/bujo/SettingsView.test.tsx
@@ -4,9 +4,14 @@ import userEvent from '@testing-library/user-event'
 import { SettingsView } from './SettingsView'
 import { SettingsProvider } from '../../contexts/SettingsContext'
 import * as WailsApp from '@/wailsjs/go/wails/App'
+import * as WailsRuntime from '@/wailsjs/runtime/runtime'
 
 vi.mock('@/wailsjs/go/wails/App', () => ({
   GetVersion: vi.fn(() => Promise.resolve('1.0.0')),
+}))
+
+vi.mock('@/wailsjs/runtime/runtime', () => ({
+  BrowserOpenURL: vi.fn(),
 }))
 
 describe('SettingsView', () => {
@@ -196,6 +201,38 @@ describe('SettingsView', () => {
 
     const themeLabel = screen.getByText('Theme').parentElement
     expect(themeLabel?.className).toContain('min-w-')
+  })
+
+  it('opens GitHub repo in system browser when GitHub link is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+
+    const githubLink = screen.getByRole('button', { name: 'GitHub' })
+    await user.click(githubLink)
+
+    expect(WailsRuntime.BrowserOpenURL).toHaveBeenCalledWith(
+      'https://github.com/typingincolor/bujo'
+    )
+  })
+
+  it('opens GitHub issues page in system browser when Support link is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+
+    const supportLink = screen.getByRole('button', { name: 'GitHub Issues' })
+    await user.click(supportLink)
+
+    expect(WailsRuntime.BrowserOpenURL).toHaveBeenCalledWith(
+      'https://github.com/typingincolor/bujo/issues'
+    )
   })
 
   it('displays backend version from API', async () => {

--- a/frontend/src/components/bujo/SettingsView.tsx
+++ b/frontend/src/components/bujo/SettingsView.tsx
@@ -3,6 +3,7 @@ import { Settings, Palette, Database, Info } from 'lucide-react';
 import { useSettings } from '../../contexts/SettingsContext';
 import type { Theme, DefaultView } from '../../types/settings';
 import { GetVersion } from '@/wailsjs/go/wails/App';
+import { BrowserOpenURL } from '@/wailsjs/runtime/runtime';
 
 export function SettingsView() {
   const { theme, setTheme, defaultView, setDefaultView } = useSettings();
@@ -82,14 +83,23 @@ export function SettingsView() {
             label="bujo"
             description="Your digital bullet journal"
           >
-            <a
-              href="https://github.com/typingincolor/bujo"
+            <button
+              onClick={() => BrowserOpenURL('https://github.com/typingincolor/bujo')}
               className="text-sm text-primary hover:underline"
-              target="_blank"
-              rel="noopener noreferrer"
             >
               GitHub
-            </a>
+            </button>
+          </SettingRow>
+          <SettingRow
+            label="Support"
+            description="Report bugs or request features"
+          >
+            <button
+              onClick={() => BrowserOpenURL('https://github.com/typingincolor/bujo/issues')}
+              className="text-sm text-primary hover:underline"
+            >
+              GitHub Issues
+            </button>
           </SettingRow>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Replace GitHub `<a href>` tag with `BrowserOpenURL` button so the link opens in the system browser instead of the Wails WebView
- Add new "Support" row linking to GitHub Issues page for bug reports and feature requests

Closes #361

## Test plan

- [x] Existing 16 settings tests pass
- [x] New test: GitHub button calls `BrowserOpenURL` with repo URL
- [x] New test: Support button calls `BrowserOpenURL` with issues URL
- [x] Full frontend suite passes (1034 tests, 78 files)
- [ ] Manual: Click GitHub link in settings → opens repo in system browser
- [ ] Manual: Click GitHub Issues link in settings → opens issues page in system browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)