### PR TITLE
fix: auto-collapse journal entries on load (#464)

### DIFF
--- a/frontend/src/lib/codemirror/BujoEditor.test.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { BujoEditor } from './BujoEditor'
 import type { DocumentError } from './errorMarkers'
+import * as bujoFolding from './bujoFolding'
 
 describe('BujoEditor', () => {
   it('renders with initial value', () => {
@@ -157,6 +158,56 @@ describe('BujoEditor', () => {
       )
 
       expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+  })
+
+  describe('auto-fold on creation', () => {
+    it('calls computeFoldAllEffects when editor is created with foldable content', () => {
+      const spy = vi.spyOn(bujoFolding, 'computeFoldAllEffects')
+
+      render(
+        <BujoEditor
+          value={'. Parent\n  . Child 1\n  . Child 2'}
+          onChange={() => {}}
+        />
+      )
+
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+
+    it('re-folds when value changes', () => {
+      const spy = vi.spyOn(bujoFolding, 'computeFoldAllEffects')
+
+      const { rerender } = render(
+        <BujoEditor
+          value={'. Parent\n  . Child 1'}
+          onChange={() => {}}
+        />
+      )
+
+      spy.mockClear()
+
+      rerender(
+        <BujoEditor
+          value={'. New Parent\n  . New Child'}
+          onChange={() => {}}
+        />
+      )
+
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+
+    it('does not error when there are no foldable lines', () => {
+      expect(() => {
+        render(
+          <BujoEditor
+            value={'. Task 1\n. Task 2'}
+            onChange={() => {}}
+          />
+        )
+      }).not.toThrow()
     })
   })
 

--- a/frontend/src/lib/codemirror/BujoEditor.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.tsx
@@ -14,7 +14,7 @@ import { bujoTheme } from './bujoTheme'
 import { priorityBadgeExtension } from './priorityBadges'
 import { indentGuidesExtension } from './indentGuides'
 import { errorHighlightExtension, setErrors } from './errorMarkers'
-import { bujoFoldExtension } from './bujoFolding'
+import { bujoFoldExtension, computeFoldAllEffects } from './bujoFolding'
 import { entryTypeStyleExtension } from './entryTypeStyles'
 import { highlightLineExtension, setHighlight } from './highlightLine'
 import { findEntryLine } from './findEntryLine'
@@ -181,10 +181,25 @@ export function BujoEditor({ value, onChange, onSave, onImport, onEscape, errors
   }, [])
 
   const handleCreateEditor = useCallback((view: EditorView) => {
+    const effects = computeFoldAllEffects(view.state)
+    if (effects.length > 0) {
+      view.dispatch({ effects })
+    }
+
     if (highlightTextRef.current) {
       applyHighlight(view)
     }
   }, [applyHighlight])
+
+  useEffect(() => {
+    const view = editorRef.current?.view
+    if (!view) return
+
+    const effects = computeFoldAllEffects(view.state)
+    if (effects.length > 0) {
+      view.dispatch({ effects })
+    }
+  }, [value])
 
   useEffect(() => {
     if (!highlightText) return


### PR DESCRIPTION
## Summary
- Add `computeFoldAllEffects` helper in `bujoFolding.ts` that generates CodeMirror fold effects for all foldable lines in an editor state
- Call fold-all on editor creation in `BujoEditor` so entries default to collapsed
- Re-fold when `value` prop changes (date navigation) to maintain collapsed state

Closes #464

## Test plan
- [x] 5 unit tests for `computeFoldAllEffects` (single parent, no foldable, multiple parents, nested, applied effects)
- [x] 2 integration tests for `BujoEditor` (fold on creation, re-fold on value change)
- [x] All 1042 frontend tests pass
- [x] All Go tests pass
- [ ] Manual: open journal view, verify entries are collapsed by default
- [ ] Manual: navigate between dates, verify entries stay collapsed
- [ ] Manual: unfold an entry with Cmd+Alt+], verify it expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)