### PR TITLE
feat: enable browser spellcheck in journal editor (#463)

### DIFF
--- a/frontend/src/lib/codemirror/BujoEditor.test.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.test.tsx
@@ -211,6 +211,21 @@ describe('BujoEditor', () => {
     })
   })
 
+  describe('spellcheck', () => {
+    it('enables spellcheck on the editor content element', () => {
+      render(
+        <BujoEditor
+          value=". Task"
+          onChange={() => {}}
+        />
+      )
+
+      const contentEl = document.querySelector('.cm-content') as HTMLElement
+      expect(contentEl).not.toBeNull()
+      expect(contentEl.spellcheck).toBe(true)
+    })
+  })
+
   describe('visual extensions', () => {
     it('displays priority badges for priority markers', () => {
       render(

--- a/frontend/src/lib/codemirror/BujoEditor.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.tsx
@@ -181,6 +181,8 @@ export function BujoEditor({ value, onChange, onSave, onImport, onEscape, errors
   }, [])
 
   const handleCreateEditor = useCallback((view: EditorView) => {
+    view.contentDOM.spellcheck = true
+
     const effects = computeFoldAllEffects(view.state)
     if (effects.length > 0) {
       view.dispatch({ effects })


### PR DESCRIPTION
## Summary

- Enables native browser spellcheck on the CodeMirror journal editor by setting `spellcheck = true` on the editor's `contentDOM` element
- Provides red squiggly underlines on misspelled words and right-click suggestions via the OS-level spell checker (macOS system spellcheck in Wails/Chromium)
- Zero dependencies added

Closes #463

## Test plan

- [x] Unit test verifies `spellcheck` attribute is set on `.cm-content` element
- [ ] Manual: open journal, type a misspelled word, verify red underline appears
- [ ] Manual: right-click misspelled word, verify suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)