### PR TITLE
feat: add automatic backup support for desktop app (#362)

### DIFF
--- a/cmd/bujo/cmd/backup.go
+++ b/cmd/bujo/cmd/backup.go
@@ -2,22 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/typingincolor/bujo/internal/app"
 )
 
 var backupDir string
-
-func getDefaultBackupDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "backups"
-	}
-	return filepath.Join(home, ".bujo", "backups")
-}
 
 var backupCmd = &cobra.Command{
 	Use:   "backup",
@@ -31,7 +22,7 @@ Backups are stored in ~/.bujo/backups/ by default.`,
 		if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
 			return err
 		}
-		backupDir = getDefaultBackupDir()
+		backupDir = app.DefaultBackupDir()
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bujo/cmd/root.go
+++ b/cmd/bujo/cmd/root.go
@@ -55,7 +55,7 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to open database: %w", err)
 		}
 
-		backupDir := getDefaultBackupDir()
+		backupDir := app.DefaultBackupDir()
 		backupRepo := sqlite.NewBackupRepository(db)
 		backupService = service.NewBackupService(backupRepo)
 		created, path, err := backupService.EnsureRecentBackup(cmd.Context(), backupDir, 7)

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +24,39 @@ func TestServiceFactory_Create_ReturnsAllServices(t *testing.T) {
 	assert.NotNil(t, services.List, "ListService should be created")
 	assert.NotNil(t, services.Goal, "GoalService should be created")
 	assert.NotNil(t, services.Stats, "StatsService should be created")
+}
+
+func TestDefaultBackupDir_ReturnsExpectedPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	expected := filepath.Join(home, ".bujo", "backups")
+	assert.Equal(t, expected, DefaultBackupDir())
+}
+
+func TestServiceFactory_Create_ReturnsBackupService(t *testing.T) {
+	ctx := context.Background()
+
+	factory := NewServiceFactory()
+	services, cleanup, err := factory.Create(ctx, ":memory:")
+	require.NoError(t, err)
+	defer cleanup()
+
+	assert.NotNil(t, services.Backup, "BackupService should be created")
+}
+
+func TestServiceFactory_Create_EnsuresRecentBackup(t *testing.T) {
+	ctx := context.Background()
+	backupDir := t.TempDir()
+
+	factory := NewServiceFactory()
+	_, cleanup, err := factory.Create(ctx, ":memory:", WithBackupDir(backupDir))
+	require.NoError(t, err)
+	defer cleanup()
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "should have created a backup file")
 }
 
 func TestServiceFactory_Create_WithInvalidPath_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire `BackupService` into `ServiceFactory` so the Wails desktop app triggers `EnsureRecentBackup` on startup, matching CLI behavior
- Extract `DefaultBackupDir()` into shared `app` package, eliminating duplication between CLI and desktop app
- Add functional options pattern (`WithBackupDir`) for testable backup directory configuration

Closes #362

## Test plan

- [x] `TestDefaultBackupDir_ReturnsExpectedPath` — verifies `~/.bujo/backups` path
- [x] `TestServiceFactory_Create_ReturnsBackupService` — verifies `Services.Backup` is wired
- [x] `TestServiceFactory_Create_EnsuresRecentBackup` — verifies backup file is created during factory initialization
- [x] All existing tests pass (`go test ./...`)
- [x] Pre-push checks pass (gofmt, build, test, vet, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)