### PR TITLE
fix: use full window width for search view (#477)

### DIFF
--- a/frontend/src/App.searchNavigation.test.tsx
+++ b/frontend/src/App.searchNavigation.test.tsx
@@ -74,6 +74,36 @@ const createMockSearchResult = (overrides: Partial<{ ID: number; Content: string
   ...overrides,
 })
 
+describe('App - Search Layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('search view container uses full width', async () => {
+    const user = userEvent.setup()
+    render(
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading your journal...')).not.toBeInTheDocument()
+    })
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await user.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/search entries/i)).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByPlaceholderText(/search entries/i)
+    const searchContainer = searchInput.closest('.max-w-full')
+    expect(searchContainer).toBeInTheDocument()
+  })
+})
+
 describe('App - Search Navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -802,7 +802,7 @@ function App() {
           )}
 
           {view === 'search' && (
-            <div className="max-w-4xl mx-auto">
+            <div className="max-w-full mx-auto">
               <SearchView
                 initialTagFilter={searchTagFilter ?? undefined}
                 initialMentionFilter={searchMentionFilter ?? undefined}


### PR DESCRIPTION
## Summary

- Changed search view container from `max-w-4xl` (896px) to `max-w-full` so the search bar, tag/mention panels, and results use the full available window width
- Fixes #477

## Test plan

- [x] Added test verifying search view container uses full width
- [x] All 40 SearchView tests pass
- [x] All pre-push checks pass (lint, tsc, test, build, audit)
- [ ] Visual verification: search bar expands to fill available space

🤖 Generated with [Claude Code](https://claude.com/claude-code)