### PR TITLE
fix: prevent nested journal entries from collapsing during editing (#478)

### DIFF
--- a/frontend/src/lib/codemirror/BujoEditor.tsx
+++ b/frontend/src/lib/codemirror/BujoEditor.tsx
@@ -41,6 +41,7 @@ export function BujoEditor({ value, onChange, onSave, onImport, onEscape, errors
   const editorRef = useRef<ReactCodeMirrorRef>(null)
   const tagCompartment = useRef(new Compartment())
 
+  const isInternalChangeRef = useRef(false)
   const onChangeRef = useRef(onChange)
   const onSaveRef = useRef(onSave)
   const onImportRef = useRef(onImport)
@@ -53,6 +54,7 @@ export function BujoEditor({ value, onChange, onSave, onImport, onEscape, errors
   })
 
   const stableOnChange = useCallback((val: string) => {
+    isInternalChangeRef.current = true
     onChangeRef.current(val)
   }, [])
 
@@ -194,6 +196,11 @@ export function BujoEditor({ value, onChange, onSave, onImport, onEscape, errors
   }, [applyHighlight])
 
   useEffect(() => {
+    if (isInternalChangeRef.current) {
+      isInternalChangeRef.current = false
+      return
+    }
+
     const view = editorRef.current?.view
     if (!view) return
 


### PR DESCRIPTION
## Summary

- Fixes #478: nested journal entries collapse on first keystroke when editing
- Added `isInternalChangeRef` to distinguish user edits (onChange-driven) from external value changes (date switch, draft restore)
- Only re-folds all entries on external value changes; user typing preserves fold state naturally via CodeMirror's fold range mapping

## Test plan

- [x] New test: "does not re-fold when content changes from user editing" - simulates user typing via EditorView.dispatch and verifies computeFoldAllEffects is NOT called
- [x] Existing test renamed: "re-folds when value changes externally" - still passes, confirms external value changes trigger fold-all
- [x] All 1065 frontend tests pass
- [x] All Go backend tests pass
- [x] Pre-push checks pass (lint, tsc, test, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)