### PR TITLE
fix: enable stats view scrolling and load 91-day data range

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -816,8 +816,10 @@ function App() {
           )}
 
           {view === 'stats' && (
-            <div className="max-w-4xl mx-auto">
-              <StatsView days={days} habits={habits} goals={goals} />
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <div className="max-w-4xl mx-auto">
+                <StatsView habits={habits} goals={goals} />
+              </div>
             </div>
           )}
 
@@ -828,8 +830,10 @@ function App() {
           )}
 
           {view === 'settings' && (
-            <div className="max-w-4xl mx-auto">
-              <SettingsView />
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <div className="max-w-4xl mx-auto">
+                <SettingsView />
+              </div>
             </div>
           )}
         </main>

--- a/frontend/src/components/bujo/StatsView.test.tsx
+++ b/frontend/src/components/bujo/StatsView.test.tsx
@@ -1,8 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import { StatsView } from './StatsView'
-import { DayEntries, Habit, Goal } from '@/types/bujo'
+import { Habit, Goal, DayEntries } from '@/types/bujo'
 import { format } from 'date-fns'
+import { GetDayEntries } from '@/wailsjs/go/wails/App'
+import { service } from '@/wailsjs/go/models'
+
+vi.mock('@/wailsjs/go/wails/App', () => ({
+  GetDayEntries: vi.fn().mockResolvedValue([]),
+}))
 
 vi.mock('./ActivityHeatmap', () => ({
   ActivityHeatmap: () => <div data-testid="activity-heatmap" />,
@@ -16,12 +22,44 @@ vi.mock('./TaskDurationChart', () => ({
   TaskDurationChart: () => <div data-testid="task-duration-chart" />,
 }))
 
+const mockedGetDayEntries = vi.mocked(GetDayEntries)
+
 const currentMonth = format(new Date(), 'yyyy-MM')
 
 const createTestDay = (entries: DayEntries['entries'] = []): DayEntries => ({
   date: new Date().toISOString(),
   entries,
 })
+
+function toApiEntries(entries: DayEntries['entries']) {
+  return entries.map(e => ({
+    ID: e.id,
+    Content: e.content,
+    Type: e.type.charAt(0).toUpperCase() + e.type.slice(1),
+    Priority: e.priority ? e.priority.charAt(0).toUpperCase() + e.priority.slice(1) : 'None',
+    ParentID: e.parentId ?? 0,
+    CreatedAt: e.loggedDate || new Date().toISOString(),
+    Children: (e.children || []).map((c: DayEntries['entries'][0]) => ({
+      ID: c.id,
+      Content: c.content,
+      Type: c.type.charAt(0).toUpperCase() + c.type.slice(1),
+      Priority: 'None',
+      ParentID: c.parentId ?? 0,
+      CreatedAt: c.loggedDate || new Date().toISOString(),
+      Children: [],
+    })),
+  }))
+}
+
+function toApiDays(days: DayEntries[]) {
+  return days.map(d => ({
+    Date: d.date,
+    Entries: toApiEntries(d.entries),
+    Location: '',
+    Mood: '',
+    Weather: '',
+  }))
+}
 
 const createTestHabit = (overrides: Partial<Habit> = {}): Habit => ({
   id: 1,
@@ -43,109 +81,145 @@ const createTestGoal = (overrides: Partial<Goal> = {}): Goal => ({
 })
 
 describe('StatsView', () => {
-  it('renders stats title', () => {
-    render(<StatsView days={[]} habits={[]} goals={[]} />)
-    expect(screen.getByText(/insights/i)).toBeInTheDocument()
+  beforeEach(() => {
+    mockedGetDayEntries.mockReset()
+    mockedGetDayEntries.mockResolvedValue([])
   })
 
-  it('displays total entry count', () => {
+  it('renders stats title', async () => {
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/insights/i)).toBeInTheDocument()
+    })
+  })
+
+  it('displays total entry count', async () => {
     const days = [createTestDay([
       { id: 1, content: 'Task 1', type: 'task', priority: 'none', parentId: null, loggedDate: '', children: [] },
       { id: 2, content: 'Note 1', type: 'note', priority: 'none', parentId: null, loggedDate: '', children: [] },
     ])]
-    render(<StatsView days={days} habits={[]} goals={[]} />)
-    expect(screen.getByText('2')).toBeInTheDocument()
+    mockedGetDayEntries.mockResolvedValue(toApiDays(days) as unknown as service.DayEntries[])
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
     expect(screen.getByText(/total entries/i)).toBeInTheDocument()
   })
 
-  it('displays task count and percentage', () => {
+  it('displays task count and percentage', async () => {
     const days = [createTestDay([
       { id: 1, content: 'Task 1', type: 'task', priority: 'none', parentId: null, loggedDate: '', children: [] },
       { id: 2, content: 'Task 2', type: 'task', priority: 'none', parentId: null, loggedDate: '', children: [] },
       { id: 3, content: 'Note 1', type: 'note', priority: 'none', parentId: null, loggedDate: '', children: [] },
     ])]
-    render(<StatsView days={days} habits={[]} goals={[]} />)
+    mockedGetDayEntries.mockResolvedValue(toApiDays(days) as unknown as service.DayEntries[])
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/67%/)).toBeInTheDocument()
+    })
     expect(screen.getByText(/tasks/i)).toBeInTheDocument()
-    expect(screen.getByText(/67%/)).toBeInTheDocument()
   })
 
-  it('displays completion rate', () => {
+  it('displays completion rate', async () => {
     const days = [createTestDay([
       { id: 1, content: 'Done task', type: 'done', priority: 'none', parentId: null, loggedDate: '', children: [] },
       { id: 2, content: 'Pending task', type: 'task', priority: 'none', parentId: null, loggedDate: '', children: [] },
     ])]
-    render(<StatsView days={days} habits={[]} goals={[]} />)
+    mockedGetDayEntries.mockResolvedValue(toApiDays(days) as unknown as service.DayEntries[])
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/50%/)).toBeInTheDocument()
+    })
     expect(screen.getByText(/completion rate/i)).toBeInTheDocument()
-    expect(screen.getByText(/50%/)).toBeInTheDocument()
   })
 
-  it('displays active habits count', () => {
+  it('displays active habits count', async () => {
     const habits = [
       createTestHabit({ id: 1, name: 'Habit 1' }),
       createTestHabit({ id: 2, name: 'Habit 2' }),
     ]
-    render(<StatsView days={[]} habits={habits} goals={[]} />)
-    expect(screen.getByText(/active habits/i)).toBeInTheDocument()
+    render(<StatsView habits={habits} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/active habits/i)).toBeInTheDocument()
+    })
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
-  it('displays best streak', () => {
+  it('displays best streak', async () => {
     const habits = [
       createTestHabit({ id: 1, streak: 5 }),
       createTestHabit({ id: 2, streak: 12 }),
       createTestHabit({ id: 3, streak: 3 }),
     ]
-    render(<StatsView days={[]} habits={habits} goals={[]} />)
-    expect(screen.getByText(/best streak/i)).toBeInTheDocument()
+    render(<StatsView habits={habits} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/best streak/i)).toBeInTheDocument()
+    })
     expect(screen.getByText(/12 days/i)).toBeInTheDocument()
   })
 
-  it('displays monthly goals progress', () => {
+  it('displays monthly goals progress', async () => {
     const goals = [
       createTestGoal({ id: 1, status: 'done' }),
       createTestGoal({ id: 2, status: 'done' }),
       createTestGoal({ id: 3, status: 'active' }),
     ]
-    render(<StatsView days={[]} habits={[]} goals={goals} />)
-    expect(screen.getByText(/monthly goals/i)).toBeInTheDocument()
+    render(<StatsView habits={[]} goals={goals} />)
+    await waitFor(() => {
+      expect(screen.getByText(/monthly goals/i)).toBeInTheDocument()
+    })
     expect(screen.getByText('2/3')).toBeInTheDocument()
   })
 
-  it('shows zero stats when no data', () => {
-    render(<StatsView days={[]} habits={[]} goals={[]} />)
-    expect(screen.getByText(/total entries/i)).toBeInTheDocument()
+  it('shows zero stats when no data', async () => {
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/total entries/i)).toBeInTheDocument()
+    })
     expect(screen.getAllByText('0').length).toBeGreaterThan(0)
   })
 
-  it('displays note count', () => {
+  it('displays note count', async () => {
     const days = [createTestDay([
       { id: 1, content: 'Note 1', type: 'note', priority: 'none', parentId: null, loggedDate: '', children: [] },
       { id: 2, content: 'Note 2', type: 'note', priority: 'none', parentId: null, loggedDate: '', children: [] },
     ])]
-    render(<StatsView days={days} habits={[]} goals={[]} />)
-    expect(screen.getByText(/notes/i)).toBeInTheDocument()
+    mockedGetDayEntries.mockResolvedValue(toApiDays(days) as unknown as service.DayEntries[])
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/notes/i)).toBeInTheDocument()
+    })
   })
 
-  it('displays event count', () => {
+  it('displays event count', async () => {
     const days = [createTestDay([
       { id: 1, content: 'Event 1', type: 'event', priority: 'none', parentId: null, loggedDate: '', children: [] },
     ])]
-    render(<StatsView days={days} habits={[]} goals={[]} />)
-    expect(screen.getByText(/events/i)).toBeInTheDocument()
+    mockedGetDayEntries.mockResolvedValue(toApiDays(days) as unknown as service.DayEntries[])
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByText(/events/i)).toBeInTheDocument()
+    })
   })
 
-  it('renders ActivityHeatmap', () => {
-    render(<StatsView days={[]} habits={[]} goals={[]} />)
-    expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
+  it('renders ActivityHeatmap', async () => {
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument()
+    })
   })
 
-  it('renders TrendsChart', () => {
-    render(<StatsView days={[]} habits={[]} goals={[]} />)
-    expect(screen.getByTestId('trends-chart')).toBeInTheDocument()
+  it('renders TrendsChart', async () => {
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('trends-chart')).toBeInTheDocument()
+    })
   })
 
-  it('renders TaskDurationChart', () => {
-    render(<StatsView days={[]} habits={[]} goals={[]} />)
-    expect(screen.getByTestId('task-duration-chart')).toBeInTheDocument()
+  it('renders TaskDurationChart', async () => {
+    render(<StatsView habits={[]} goals={[]} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('task-duration-chart')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Fixed stats and settings views not scrolling when content exceeds viewport by adding `flex-1 min-h-0 overflow-y-auto` wrapper
- Made StatsView fetch its own 91-day data range via `GetDayEntries` instead of relying on the parent's 7-day data, fixing the empty activity heatmap
- Updated test suite with proper async patterns and Wails API mocking

## Test plan
- [x] All 13 StatsView tests pass
- [x] ESLint passes clean on all changed files
- [x] TypeScript compilation succeeds
- [x] Frontend build succeeds
- [ ] Manual: verify stats view scrolls when content overflows
- [ ] Manual: verify activity heatmap displays data

🤖 Generated with [Claude Code](https://claude.com/claude-code)