### PR TITLE
feat: line wrapping, CLI ID output, refresh button, link opening

### DIFF
--- a/cmd/bujo/cmd/add.go
+++ b/cmd/bujo/cmd/add.go
@@ -3,12 +3,19 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/typingincolor/bujo/internal/service"
 )
+
+func writeEntryIDs(w io.Writer, ids []int64) {
+	for _, id := range ids {
+		fmt.Fprintln(w, id)
+	}
+}
 
 var addCmd = &cobra.Command{
 	Use:   "add [entries...]",
@@ -101,6 +108,7 @@ Examples:
 			return fmt.Errorf("failed to add entries: %w", err)
 		}
 
+		writeEntryIDs(os.Stdout, ids)
 		fmt.Fprintf(os.Stderr, "Added %d entry(s)\n", len(ids))
 		return nil
 	},

--- a/cmd/bujo/cmd/add_test.go
+++ b/cmd/bujo/cmd/add_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteEntryIDs(t *testing.T) {
+	t.Run("writes each ID on its own line", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeEntryIDs(&buf, []int64{42, 99, 7})
+		got := buf.String()
+		want := "42\n99\n7\n"
+		if got != want {
+			t.Errorf("writeEntryIDs() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty IDs writes nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeEntryIDs(&buf, []int64{})
+		got := buf.String()
+		if got != "" {
+			t.Errorf("writeEntryIDs() = %q, want empty", got)
+		}
+	})
+
+	t.Run("single ID", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeEntryIDs(&buf, []int64{123})
+		got := buf.String()
+		want := "123\n"
+		if got != want {
+			t.Errorf("writeEntryIDs() = %q, want %q", got, want)
+		}
+	})
+}

--- a/frontend/src/components/bujo/JournalView.tsx
+++ b/frontend/src/components/bujo/JournalView.tsx
@@ -5,6 +5,7 @@ import { BujoEditor } from '@/lib/codemirror/BujoEditor'
 import { scanForNewSpecialEntries, SpecialEntries } from '@/hooks/useSaveWithDialogs'
 import { MigrateBatchModal } from '@/components/bujo/MigrateBatchModal'
 import { ListPickerModal } from '@/components/bujo/ListPickerModal'
+import { RefreshCw } from 'lucide-react'
 
 interface JournalViewProps {
   date: Date
@@ -21,6 +22,7 @@ export function JournalView({ date, highlightText, onHighlightDone }: JournalVie
     error,
     isDirty,
     validationErrors,
+    reload,
     save,
     saveWithActions,
     discardChanges,
@@ -226,6 +228,7 @@ export function JournalView({ date, highlightText, onHighlightDone }: JournalVie
         <span><kbd>⌥↓</kbd> Move down</span>
         <span><kbd>⌃A</kbd> Line start</span>
         <span><kbd>⌃E</kbd> Line end</span>
+        <span><kbd>⌘Click</kbd> Open link</span>
       </div>
 
       {validationErrors.length > 0 && (
@@ -277,6 +280,13 @@ export function JournalView({ date, highlightText, onHighlightDone }: JournalVie
               Discard
             </button>
           )}
+          <button
+            onClick={reload}
+            title="Reload entries"
+            className="p-1.5 hover:bg-secondary rounded-md transition-colors"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </button>
         </div>
       </div>
 

--- a/frontend/src/hooks/useEditableDocument.ts
+++ b/frontend/src/hooks/useEditableDocument.ts
@@ -37,6 +37,7 @@ export interface EditableDocumentState {
   error: string | null
   isDirty: boolean
   validationErrors: ValidationError[]
+  reload: () => Promise<void>
   save: () => Promise<SaveResult>
   saveWithActions: (actions: SaveActions) => Promise<SaveResult>
   discardChanges: () => void
@@ -133,6 +134,23 @@ export function useEditableDocument(date: Date): EditableDocumentState {
         clearTimeout(debounceTimerRef.current)
         debounceTimerRef.current = null
       }
+    }
+  }, [date, checkForDraft])
+
+  const reload = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    setValidationErrors([])
+
+    try {
+      const result = await GetEditableDocument(toWailsTime(date))
+      setDocumentState(result)
+      setOriginalDocument(result)
+      setIsLoading(false)
+      checkForDraft(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setIsLoading(false)
     }
   }, [date, checkForDraft])
 
@@ -271,6 +289,7 @@ export function useEditableDocument(date: Date): EditableDocumentState {
     error,
     isDirty,
     validationErrors,
+    reload,
     save,
     saveWithActions,
     discardChanges,


### PR DESCRIPTION
## Summary

Implements four enhancement issues:

- **#490**: Enable line wrapping in journal editor via `EditorView.lineWrapping`
- **#488**: Print created entry IDs to stdout from `bujo add` for scripting (TDD)
- **#489**: Add reload button to journal view bottom bar
- **#491**: Open URLs in browser via Cmd+click in journal editor

## Test plan

- [x] Go tests pass (`go test ./...`) — includes new `TestWriteEntryIDs` tests
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [ ] Manual: Open journal with long entry, confirm wrapping
- [ ] Manual: Run `./bujo --db-path :memory: add ". Test"`, verify IDs on stdout
- [ ] Manual: Click reload button, verify document refreshes from DB
- [ ] Manual: Cmd+click a URL in journal, verify browser opens

Closes #488, closes #489, closes #490, closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)