### PR TITLE
feat: add Gmail bookmarklet install link to settings page

### DIFF
--- a/frontend/src/components/bujo/SettingsView.test.tsx
+++ b/frontend/src/components/bujo/SettingsView.test.tsx
@@ -235,6 +235,41 @@ describe('SettingsView', () => {
     )
   })
 
+  it('displays integrations section', () => {
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+    expect(screen.getByText('Integrations')).toBeInTheDocument()
+  })
+
+  it('displays Gmail bookmarklet link in integrations section', () => {
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+    expect(screen.getByText('Gmail Bookmarklet')).toBeInTheDocument()
+    expect(screen.getByText('Capture emails as tasks directly from Gmail')).toBeInTheDocument()
+  })
+
+  it('opens bookmarklet install page when Install link is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <SettingsProvider>
+        <SettingsView />
+      </SettingsProvider>
+    )
+
+    const installLink = screen.getByRole('button', { name: 'Install' })
+    await user.click(installLink)
+
+    expect(WailsRuntime.BrowserOpenURL).toHaveBeenCalledWith(
+      'http://127.0.0.1:8743/install'
+    )
+  })
+
   it('displays backend version from API', async () => {
     vi.mocked(WailsApp.GetVersion).mockResolvedValue('v0.1.0-nightly+85d8787')
 

--- a/frontend/src/components/bujo/SettingsView.tsx
+++ b/frontend/src/components/bujo/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Settings, Palette, Database, Info } from 'lucide-react';
+import { Settings, Palette, Database, Info, Mail } from 'lucide-react';
 import { useSettings } from '../../contexts/SettingsContext';
 import type { Theme, DefaultView } from '../../types/settings';
 import { GetVersion } from '@/wailsjs/go/wails/App';
@@ -60,6 +60,29 @@ export function SettingsView() {
             <span className="text-xs text-muted-foreground">
               ~/.bujo/bujo.db
             </span>
+          </SettingRow>
+        </div>
+      </section>
+
+      {/* Integrations Section */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Mail className="w-4 h-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Integrations
+          </h3>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+          <SettingRow
+            label="Gmail Bookmarklet"
+            description="Capture emails as tasks directly from Gmail"
+          >
+            <button
+              onClick={() => BrowserOpenURL('http://127.0.0.1:8743/install')}
+              className="text-sm text-primary hover:underline"
+            >
+              Install
+            </button>
           </SettingRow>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Adds an **Integrations** section to the Settings page with a Gmail Bookmarklet install link
- Clicking "Install" opens the bookmarklet install page (`http://127.0.0.1:8743/install`) in the system browser
- Follows existing Settings page patterns (Mail icon, SettingRow component, BrowserOpenURL)

Closes #496

## Test plan
- [x] New test: Integrations section renders
- [x] New test: Gmail Bookmarklet label and description render
- [x] New test: Install button opens correct URL via BrowserOpenURL
- [x] All 1104 frontend tests pass
- [x] Pre-push checks pass (lint, tsc, test, build, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)